### PR TITLE
Apps launcher improvement

### DIFF
--- a/core/helper-tools/src/main/java/esa/mo/helpertools/helpers/HelperMisc.java
+++ b/core/helper-tools/src/main/java/esa/mo/helpertools/helpers/HelperMisc.java
@@ -64,6 +64,7 @@ public class HelperMisc {
   public final static String APP_CATEGORY = "helpertools.configurations.provider.app.category";
   public final static String APP_COPYRIGHT = "helpertools.configurations.provider.app.copyright";
   public final static String APP_DESCRIPTION = "helpertools.configurations.provider.app.description";
+  public final static String APP_USER = "helpertools.configurations.provider.app.user";
 
   public static final String PROP_MO_APP_NAME = "helpertools.configurations.MOappName";
   public static final String PROP_DOMAIN = "helpertools.configurations.provider.Domain";

--- a/core/helper-tools/src/main/java/esa/mo/helpertools/helpers/HelperMisc.java
+++ b/core/helper-tools/src/main/java/esa/mo/helpertools/helpers/HelperMisc.java
@@ -343,7 +343,7 @@ public class HelperMisc {
   }
 
   /**
-   * Generates the corresponding MAL Element List from a certain MAL Element
+   * Generates a corresponding, empty MAL Element List from a certain MAL Element
    *
    * @param obj The MAL Element
    * @return The MAL Element List
@@ -378,7 +378,7 @@ public class HelperMisc {
   }
 
   /**
-   * Generates the corresponding MAL Element from a certain MAL Element List
+   * Generates the corresponding, empty MAL Element from a certain MAL Element List
    *
    * @param obj The MAL Element List
    * @return The MAL Element

--- a/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherManager.java
+++ b/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherManager.java
@@ -390,8 +390,11 @@ public class AppsLauncherManager extends DefinitionsManager
       ret.add("/c");
       ret.add("start_" + trimmedAppName + ".bat");
     } else {
-      ret.add("/bin/sh");
-      ret.add("start_" + trimmedAppName + ".sh");
+      ret.add("su");
+      ret.add("-");
+      ret.add(trimmedAppName);
+      ret.add("-c");
+      ret.add("'./start_" + trimmedAppName + ".sh'");
     }
     return ret.toArray(new String[ret.size()]);
   }

--- a/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherManager.java
+++ b/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherManager.java
@@ -390,11 +390,19 @@ public class AppsLauncherManager extends DefinitionsManager
       ret.add("/c");
       ret.add("start_" + trimmedAppName + ".bat");
     } else {
-      ret.add("su");
-      ret.add("-");
-      ret.add(runAs);
-      ret.add("-c");
-      ret.add("'./start_" + trimmedAppName + ".sh'");
+      String quote = "";
+      if(runAs != null){
+        ret.add("su");
+        ret.add("-");
+        ret.add(runAs);
+        ret.add("-m");
+        ret.add("-c");
+        quote = "'";
+      } else {
+        ret.add("/bin/sh");
+      }
+      
+      ret.add(quote+"./start_" + trimmedAppName + ".sh"+quote); // Ugly workaround but works!
     }
     return ret.toArray(new String[ret.size()]);
   }
@@ -705,7 +713,7 @@ public class AppsLauncherManager extends DefinitionsManager
           getProperty(HelperMisc.APP_DESCRIPTION) : "-";
       final String user = (props.getProperty(HelperMisc.APP_USER) != null) ? props.getProperty(
           HelperMisc.APP_USER)
-          : "`whoami`"; // Since the user change is only implemented on linux this dependency is fine
+          : null; // Since the user change is only implemented on linux this dependency is fine
 
       app.setCategory(new Identifier(category));
       app.setVersion(version);

--- a/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherManager.java
+++ b/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherManager.java
@@ -381,7 +381,7 @@ public class AppsLauncherManager extends DefinitionsManager
     return ret.toArray(new String[ret.size()]);
   }
 
-  protected String[] assembleAppLauncherCommand(final String appName)
+  protected String[] assembleAppLauncherCommand(final String appName, String runAs)
   {
     ArrayList<String> ret = new ArrayList<>();
     String trimmedAppName = appName.replaceAll("space-app-", "");
@@ -392,7 +392,7 @@ public class AppsLauncherManager extends DefinitionsManager
     } else {
       ret.add("su");
       ret.add("-");
-      ret.add(trimmedAppName);
+      ret.add(runAs);
       ret.add("-c");
       ret.add("'./start_" + trimmedAppName + ".sh'");
     }
@@ -421,7 +421,8 @@ public class AppsLauncherManager extends DefinitionsManager
     // Go to the folder where the app are installed
     final File appFolder
         = new File(appsFolderPath + File.separator + app.getName().getValue());
-    final String[] appLauncherCommand = assembleAppLauncherCommand(app.getName().getValue());
+    final String[] appLauncherCommand = assembleAppLauncherCommand(app.getName().getValue(),
+        app.getRunAs());
 
     final ProcessBuilder pb = new ProcessBuilder(appLauncherCommand);
     Map<String, String> env = pb.environment();
@@ -462,11 +463,11 @@ public class AppsLauncherManager extends DefinitionsManager
     return true;
   }
 
-  protected boolean stopNativeApp(final Long appInstId, MALInteraction interaction) throws IOException
+  protected boolean stopNativeApp(final Long appInstId, MALInteraction interaction) throws
+      IOException
   {
     ProcessExecutionHandler handler = handlers.get(appInstId);
     AppDetails app = (AppDetails) this.getDef(appInstId); // get it from the list of available apps
-
 
     // Go to the folder where the app are installed
     final File appFolder
@@ -483,7 +484,6 @@ public class AppsLauncherManager extends DefinitionsManager
         new Object[]{app.getName().getValue(), appFolder.getAbsolutePath(), Arrays.toString(
           appLauncherCommand), Arrays.toString(EnvironmentUtils.toStrings(env))});
     final Process proc = pb.start();
-
 
     if (handler == null) {
       app.setRunning(false);
@@ -703,11 +703,15 @@ public class AppsLauncherManager extends DefinitionsManager
           getProperty(HelperMisc.APP_COPYRIGHT) : "-";
       final String description = (props.getProperty(HelperMisc.APP_DESCRIPTION) != null) ? props.
           getProperty(HelperMisc.APP_DESCRIPTION) : "-";
+      final String user = (props.getProperty(HelperMisc.APP_USER) != null) ? props.getProperty(
+          HelperMisc.APP_USER)
+          : "`whoami`"; // Since the user change is only implemented on linux this dependency is fine
 
       app.setCategory(new Identifier(category));
       app.setVersion(version);
       app.setCopyright(copyright);
       app.setDescription(description);
+      app.setRunAs(user);
 
       app.setRunAtStartup(false); // This is not supported in this implementation
       app.setRunning(false); // Default values

--- a/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherManager.java
+++ b/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherManager.java
@@ -444,7 +444,6 @@ public class AppsLauncherManager extends DefinitionsManager
         new Object[]{app.getName().getValue(), appFolder.getAbsolutePath(), Arrays.toString(
           appLauncherCommand), Arrays.toString(EnvironmentUtils.toStrings(env))});
     final Process proc = pb.start();
-    System.out.println("PROCESS STARTED");
     handler.monitorProcess(proc);
     Runtime.getRuntime().addShutdownHook(new Thread(() -> proc.destroy()));
     handlers.put(handler.getObjId(), handler);

--- a/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherProviderServiceImpl.java
+++ b/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherProviderServiceImpl.java
@@ -261,10 +261,8 @@ public class AppsLauncherProviderServiceImpl extends AppsLauncherInheritanceSkel
           directoryServiceURI
               = directoryService.getConnection().getConnectionDetails().getProviderURI().toString();
         }
-        System.out.println("DIRURI: " + directoryServiceURI);
         manager.startAppProcess(new ProcessExecutionHandler(new CallbacksImpl(), appInstIds.get(i)),
             interaction, directoryServiceURI);
-        System.out.println("FOOBAR");
       } catch (IOException ex) {
         UIntegerList intIndexList = new UIntegerList();
         intIndexList.add(new UInteger(i));

--- a/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherProviderServiceImpl.java
+++ b/core/mo-services-impl/nmf-software-management-impl/src/main/java/esa/mo/sm/impl/provider/AppsLauncherProviderServiceImpl.java
@@ -356,7 +356,7 @@ public class AppsLauncherProviderServiceImpl extends AppsLauncherInheritanceSkel
       }
     }
 
-    IdentifierList appDirectoryNames = new IdentifierList();
+    IdentifierList appDirectoryServiceNames = new IdentifierList();
 
     for (int i = 0; i < appInstIds.size(); i++) {
       // Get it from the list of available apps
@@ -398,9 +398,9 @@ public class AppsLauncherProviderServiceImpl extends AppsLauncherInheritanceSkel
 
           // Add to the list of Directory service Obj Ids
           if (!providersList.isEmpty()) {
-            appDirectoryNames.add(providersList.get(0).getProviderName());
+            appDirectoryServiceNames.add(providersList.get(0).getProviderName());
           } else {
-            appDirectoryNames.add(null);
+            appDirectoryServiceNames.add(null);
           }
         } catch (IOException ex) {
           intIndexList.add(new UInteger(i)); // Throw an INTERNAL error
@@ -425,7 +425,8 @@ public class AppsLauncherProviderServiceImpl extends AppsLauncherInheritanceSkel
     }
 
     interaction.sendAcknowledgement();
-    manager.stopApps(appInstIds, appDirectoryNames, appConnections, interaction);
+    manager.stopApps(appInstIds, appDirectoryServiceNames, appConnections, interaction);
+    interaction.sendResponse();
   }
 
   @Override

--- a/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/services/sm/AppsLauncherTablePanel.java
+++ b/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/services/sm/AppsLauncherTablePanel.java
@@ -35,6 +35,7 @@ import org.ccsds.moims.mo.softwaremanagement.appslauncher.structures.AppDetails;
  */
 public class AppsLauncherTablePanel extends SharedTablePanel {
 
+    private static final Logger LOGGER = Logger.getLogger(AppsLauncherTablePanel.class.getName());
     public AppsLauncherTablePanel(ArchiveConsumerServiceImpl archiveService) {
         super(archiveService);
     }
@@ -42,7 +43,7 @@ public class AppsLauncherTablePanel extends SharedTablePanel {
     @Override
     public void addEntry(final Identifier name, final ArchivePersistenceObject comObject) {
         if (comObject == null){
-            Logger.getLogger(SharedTablePanel.class.getName()).log(Level.SEVERE, 
+            LOGGER.log(Level.SEVERE,
                     "The table cannot process a null COM Object.");
             return;
         }
@@ -50,7 +51,7 @@ public class AppsLauncherTablePanel extends SharedTablePanel {
         try {
             semaphore.acquire();
         } catch (InterruptedException ex) {
-            Logger.getLogger(SharedTablePanel.class.getName()).log(Level.SEVERE, null, ex);
+            LOGGER.log(Level.SEVERE, null, ex);
         }
             
         AppDetails appDetails = (AppDetails) comObject.getObject();
@@ -73,7 +74,7 @@ public class AppsLauncherTablePanel extends SharedTablePanel {
         try {
             semaphore.acquire();
         } catch (InterruptedException ex) {
-            Logger.getLogger(SharedTablePanel.class.getName()).log(Level.SEVERE, null, ex);
+            LOGGER.log(Level.SEVERE, null, ex);
         }
 
         // 4 because it is where generationEnabled is!
@@ -87,7 +88,7 @@ public class AppsLauncherTablePanel extends SharedTablePanel {
         try {
             semaphore.acquire();
         } catch (InterruptedException ex) {
-            Logger.getLogger(SharedTablePanel.class.getName()).log(Level.SEVERE, null, ex);
+            LOGGER.log(Level.SEVERE, null, ex);
         }
 
         // 5 because it is where the flag is!
@@ -103,9 +104,9 @@ public class AppsLauncherTablePanel extends SharedTablePanel {
         try {
             semaphore.acquire();
         } catch (InterruptedException ex) {
-            Logger.getLogger(SharedTablePanel.class.getName()).log(Level.SEVERE, null, ex);
+            LOGGER.log(Level.SEVERE, null, ex);
         }
-
+        LOGGER.log(Level.INFO, "Updating test for appId {0}: ''{1}''", new Object[]{appId, text});
         
         int index;
         try {
@@ -114,7 +115,7 @@ public class AppsLauncherTablePanel extends SharedTablePanel {
             // 6 because it is where the status field is!
             tableData.setValueAt(text, index, 6);
         } catch (Exception ex) {
-            Logger.getLogger(AppsLauncherTablePanel.class.getName()).log(Level.SEVERE, null, ex);
+            LOGGER.log(Level.SEVERE, null, ex);
         }
         
         semaphore.release();


### PR DESCRIPTION
This PR addresses the following issues:
* Bug #330: Supervisor should not execute experiments as root
* Bug #531: Stop app handling is not implemented for native and mixed apps

## Bug #330: Supervisor should not execute experiments as root
**Goal:** By default, apps are launched as the currently logged in user, i.e. root on the satellite. The new implementation should launch apps by their respective user on the satellite.
**Implementation:** The AppsLauncherManager now checks for a user property in provider.properties and uses its value to set the runAs value of the corresponding AppDetails. This field is populated by the package script of https://github.com/esa/nmf-mission-ops-sat. If the user property is not existent the AppsLauncherManager assumes an SDK environment and executes the app as the current user. Taking the app name as a default does not work, as this will fail for payloads-test.

## Bug #531: Stop app handling is not implemented for native and mixed apps
**Goal:** Allow native (non-NMF) and mixed apps (NMF + native components) to shut down gracefully when calling stopApp. Before implementation, calling stopApp on a Non_NMF_App results in an exception in the supervisor, suggesting to use killApp which will terminate the process immediately. Instead, stopApp should invoke stop_$APPNAME.sh if existent and take care of the shutdown process.
**Implementation:** Refactoring of stopApp into two methods: stopNMFApp and stopNativeApp. The procedure is: call stop script if existent and then proceed to shutdown the app if it's an NMF app. If the selected app is not an NMF app and no stop script is present, the app will be killed.

Feel free to ask any questions!