### PR TITLE
[GroundMOAdapterImpl] Make action-instance-ID unique

### DIFF
--- a/core/mo-services-impl/ccsds-com-impl/src/main/java/esa/mo/com/impl/util/ObjectInstanceIdGenerator.java
+++ b/core/mo-services-impl/ccsds-com-impl/src/main/java/esa/mo/com/impl/util/ObjectInstanceIdGenerator.java
@@ -1,0 +1,75 @@
+/* ----------------------------------------------------------------------------
+ * Copyright (C) 2015      European Space Agency
+ *                         European Space Operations Centre
+ *                         Darmstadt
+ *                         Germany
+ * ----------------------------------------------------------------------------
+ * System                : ESA NanoSat MO Framework
+ * ----------------------------------------------------------------------------
+ * Licensed under the European Space Agency Public License, Version 2.0
+ * You may not use this file except in compliance with the License.
+ *
+ * Except as expressly set forth in this License, the Software is provided to
+ * You on an "as is" basis and without warranties of any kind, including without
+ * limitation merchantability, fitness for a particular purpose, absence of
+ * defects or errors, accuracy or non-infringement of intellectual property rights.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+package esa.mo.com.impl.util;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Singleton class for generating Unique Object Instance IDs.
+ *
+ * @author Kevin Otto <Kevin@KevinOtto.de>
+ */
+public class ObjectInstanceIdGenerator
+{
+
+  private static ObjectInstanceIdGenerator instance;
+
+  private final long EPOCH2020 = 1577836800;
+  private final Random RNG = new Random(System.nanoTime());
+  private final AtomicInteger objectInstanceIdCounter = new AtomicInteger(0);
+
+  private long lastObjectInstanceIdTimeStamp = 0;
+
+  /**
+   * Returns the Singleton instance of ObjectInstanceIdGenerator. The instance will be generated if
+   * necessary.
+   *
+   * @return Singleton instance of ObjectInstanceIdGenerator
+   */
+  public static ObjectInstanceIdGenerator getInstance()
+  {
+    if (instance == null) {
+      instance = new ObjectInstanceIdGenerator();
+    }
+    return instance;
+  }
+
+  /**
+   * Creates a new unique actionID.
+   *
+   * ID consists of 40 bit timestamp, 12 bit counter and 12 bit random Number. The counter counts
+   * the amount of generated IDs in the current Millisecond.
+   *
+   * @return a Unique action ID
+   */
+  public synchronized long generateObjectInstanceId()
+  {
+    long time = System.currentTimeMillis();
+
+    if (lastObjectInstanceIdTimeStamp != time) {
+      lastObjectInstanceIdTimeStamp = time;
+      objectInstanceIdCounter.set(0);
+    }
+    int newId = objectInstanceIdCounter.getAndIncrement();
+    return ((time - EPOCH2020) << 24) + (newId << 12) + RNG.nextInt(4096);
+  }
+}

--- a/core/mo-services-impl/ccsds-com-impl/src/test/java/esa/nmf/test/RegressionTest.java
+++ b/core/mo-services-impl/ccsds-com-impl/src/test/java/esa/nmf/test/RegressionTest.java
@@ -4,7 +4,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ RegressionTest0.class, RegressionTest1.class, RegressionTest2.class, RegressionTest3.class, RegressionTest4.class, RegressionTest5.class })
-public class RegressionTest {
+@Suite.SuiteClasses({RegressionTest0.class, RegressionTest1.class, RegressionTest2.class,
+  RegressionTest3.class, RegressionTest4.class, RegressionTest5.class, UniqueIDTest.class})
+public class RegressionTest
+{
 }
-

--- a/core/mo-services-impl/ccsds-com-impl/src/test/java/esa/nmf/test/UniqueIDTest.java
+++ b/core/mo-services-impl/ccsds-com-impl/src/test/java/esa/nmf/test/UniqueIDTest.java
@@ -1,0 +1,92 @@
+package esa.nmf.test;
+
+import esa.mo.com.impl.util.ObjectInstanceIdGenerator;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author Kevin Otto <Kevin@KevinOtto.de>
+ */
+public class UniqueIDTest
+{
+
+  public static boolean debug = true;
+
+  // number of threads to run in generate IDs in parallel.
+  private static final int NUM_THREADS = 100;
+
+  private static boolean[] results = new boolean[NUM_THREADS];
+  private static LinkedList<Long>[] idLists = new LinkedList[NUM_THREADS];
+  private static HashSet<Long> unique = new HashSet<>();
+
+  private class IDRunner implements Runnable
+  {
+
+    private final int threadNumber;
+
+    public IDRunner(int threadNumber)
+    {
+      this.threadNumber = threadNumber;
+    }
+
+    @Override
+    public void run()
+    {
+      for (int i = 0; i < 10000; i++) {
+        long id = ObjectInstanceIdGenerator.getInstance().generateObjectInstanceId();
+        synchronized (unique) {
+          results[threadNumber] = unique.add(id);
+          idLists[threadNumber].add(id);
+          if (!results[threadNumber]) {
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  public void printBinary(long id)
+  {
+    for (int x = 0; x < Long.numberOfLeadingZeros((long) id); x++) {
+      System.out.print('0');
+    }
+    System.out.println(Long.toBinaryString((long) id));
+  }
+
+  @Test
+  public void test0()
+  {
+    Thread[] threads = new Thread[NUM_THREADS];
+    for (int i = 0; i < threads.length; i++) {
+      idLists[i] = new LinkedList<>();
+      threads[i] = new Thread(new IDRunner(i));
+    }
+
+    for (Thread thread : threads) {
+      thread.start();
+    }
+
+    for (int i = 0; i < threads.length; i++) {
+      try {
+        threads[i].join();
+
+        if (!results[i] && debug) {
+          System.err.println("Threadd ID = " + i);
+          for (Long id : idLists[i]) {
+            System.err.println(id);
+            printBinary(id);
+          }
+        }
+        Assert.assertTrue(results[i]);
+
+      } catch (InterruptedException ex) {
+        Logger.getLogger(UniqueIDTest.class.getName()).log(Level.SEVERE, null, ex);
+      }
+    }
+  }
+}

--- a/core/nmf-composites/ground-mo-adapter/src/main/java/esa/mo/nmf/groundmoadapter/SimpleCommandingInterface.java
+++ b/core/nmf-composites/ground-mo-adapter/src/main/java/esa/mo/nmf/groundmoadapter/SimpleCommandingInterface.java
@@ -25,61 +25,57 @@ import java.io.Serializable;
 import org.ccsds.moims.mo.mc.structures.AttributeValueList;
 
 /**
- * The SimpleCommandingInterface interface provides a simpler way to send
- * commands to a NanoSat MO Framework-based provider. Hides the complexity of
- * the MO services by providing direct Java data types injection.
+ * The SimpleCommandingInterface interface provides a simpler way to send commands to a NanoSat MO
+ * Framework-based provider. Hides the complexity of the MO services by providing direct Java data
+ * types injection.
  *
  * @author Cesar Coelho
  */
-public interface SimpleCommandingInterface {
+public interface SimpleCommandingInterface
+{
 
-    /**
-     * The setParameter method allows an external software entity to send Data
-     * to the NanoSat MO Framework provider using the Parameter service. If
-     * there is no parameter definition with the submitted name, the method
-     * shall automatically create the parameter definition in the Parameter
-     * service. Any sort of data can be exchanged as long as the content is
-     * serializable.
-     *
-     * @param parameterName The name of the Parameter as set in the parameter
-     * definition
-     * @param content The content of the Parameter
-     */
-    void setParameter(String parameterName, Serializable content);
+  /**
+   * The setParameter method allows an external software entity to send Data to the NanoSat MO
+   * Framework provider using the Parameter service. If there is no parameter definition with the
+   * submitted name, the method shall automatically create the parameter definition in the Parameter
+   * service. Any sort of data can be exchanged as long as the content is serializable.
+   *
+   * @param parameterName The name of the Parameter as set in the parameter definition
+   * @param content       The content of the Parameter
+   */
+  void setParameter(String parameterName, Serializable content);
 
-    /**
-     * The addDataReceivedListener method allows an external software entity to
-     * submit a DataReceivedListener in order to receive Data from the NanoSat
-     * MO Framework provider using the Parameter service.
-     *
-     * @param dataReceivedListener The Listener where the data will be received
-     */
-    void addDataReceivedListener(DataReceivedListener dataReceivedListener);
+  /**
+   * The addDataReceivedListener method allows an external software entity to submit a
+   * DataReceivedListener in order to receive Data from the NanoSat MO Framework provider using the
+   * Parameter service.
+   *
+   * @param dataReceivedListener The Listener where the data will be received
+   */
+  void addDataReceivedListener(DataReceivedListener dataReceivedListener);
 
-    /**
-     * The invokeAction method allows an external software entity to submit an
-     * Action to the NanoSat MO Framework provider just by selecting the name of
-     * the action and the respective implementer-specific data necessary for the
-     * execution of that action.
-     *
-     * @param actionName The name of the Action to be executed
-     * @param objects Implementer-specific data necessary to execute the action
-     */
-    void invokeAction(String actionName, Serializable[] objects);
+  /**
+   * The invokeAction method allows an external software entity to submit an Action to the NanoSat
+   * MO Framework provider just by selecting the name of the action and the respective
+   * implementer-specific data necessary for the execution of that action.
+   *
+   * @param actionName The name of the Action to be executed
+   * @param objects    Implementer-specific data necessary to execute the action
+   */
+  Long invokeAction(String actionName, Serializable[] objects);
 
-    /**
-     * The invokeAction method allows an external software entity to invoke an
-     * action using the Action service by selecting the defInstId of
-     * the action and the respective argument values necessary for the
-     * execution of that action.
-     *
-     * @param defInstId The object instance identifier of the ActionDefinition
-     * @param argumentValues List containing the values of the arguments. The
-     * ordering of the list matches that of the definition
-     * @return The object instance identifier of the ActionInstance. This can be
-     * used to track the action via the Activity Tracking service.
-     * @throws NMFException in case something goes wrong
-     */
-    Long invokeAction(Long defInstId, AttributeValueList argumentValues) throws NMFException;
+  /**
+   * The invokeAction method allows an external software entity to invoke an action using the Action
+   * service by selecting the defInstId of the action and the respective argument values necessary
+   * for the execution of that action.
+   *
+   * @param defInstId      The object instance identifier of the ActionDefinition
+   * @param argumentValues List containing the values of the arguments. The ordering of the list
+   *                       matches that of the definition
+   * @return The object instance identifier of the ActionInstance. This can be used to track the
+   * action via the Activity Tracking service.
+   * @throws NMFException in case something goes wrong
+   */
+  Long invokeAction(Long defInstId, AttributeValueList argumentValues) throws NMFException;
 
 }


### PR DESCRIPTION
Adds a Method to create Unique action-instance IDs,
also changed the return statement of invokeAction to Long to be able to return the instance ID