### PR TITLE
[Simulator] Fix TLE error when Orekit propagator is deactivated

### DIFF
--- a/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/orekit/OrekitCore.java
+++ b/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/orekit/OrekitCore.java
@@ -38,13 +38,13 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import opssat.simulator.threading.SimulatorNode;
+import opssat.simulator.util.SimulatorHeader;
+import org.hipparchus.geometry.euclidean.threed.Rotation;
+import org.hipparchus.geometry.euclidean.threed.RotationConvention;
+import org.hipparchus.geometry.euclidean.threed.RotationOrder;
 import org.hipparchus.geometry.euclidean.threed.Vector3D;
-/*import org.apache.commons.math3.geometry.euclidean.threed.Rotation;
-import org.apache.commons.math3.geometry.euclidean.threed.RotationConvention;
-import org.apache.commons.math3.geometry.euclidean.threed.RotationOrder;
-import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
-import org.apache.commons.math3.util.FastMath;*/
+import org.hipparchus.util.FastMath;
 import org.orekit.attitudes.Attitude;
 import org.orekit.attitudes.AttitudeProvider;
 import org.orekit.attitudes.AttitudesSequence;
@@ -70,6 +70,7 @@ import org.orekit.models.earth.GeoMagneticField;
 import org.orekit.models.earth.GeoMagneticFieldFactory;
 import org.orekit.orbits.KeplerianOrbit;
 import org.orekit.orbits.Orbit;
+import org.orekit.orbits.OrbitType;
 import org.orekit.orbits.PositionAngle;
 import org.orekit.propagation.AbstractPropagator;
 import org.orekit.propagation.SpacecraftState;
@@ -83,14 +84,6 @@ import org.orekit.utils.AngularDerivativesFilter;
 import org.orekit.utils.Constants;
 import org.orekit.utils.IERSConventions;
 import org.orekit.utils.PVCoordinatesProvider;
-
-import opssat.simulator.threading.SimulatorNode;
-import opssat.simulator.util.SimulatorHeader;
-import org.hipparchus.geometry.euclidean.threed.Rotation;
-import org.hipparchus.geometry.euclidean.threed.RotationConvention;
-import org.hipparchus.geometry.euclidean.threed.RotationOrder;
-import org.hipparchus.util.FastMath;
-import org.orekit.orbits.OrbitType;
 
 /**
  *
@@ -1282,13 +1275,10 @@ public class OrekitCore
    */
   public TLE getTLE()
   {
-    System.out.println("getTLE!");
 
     if (this.runningPropagator instanceof TLEPropagator) {
-      System.out.println("TLEPropagator");
       return ((TLEPropagator) this.runningPropagator).getTLE();
     } else { // in case we are using the keplerian propagator, the TLE can not be reconstructed completle!
-      System.out.println("KeplerianPropagator");
       this.logger.log(Level.WARNING,
           "Using getTLE() with any other than the TLEPropagator results in incomplete and inaccurate TLE Messages!"
           + "\n"

--- a/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/threading/SimulatorNode.java
+++ b/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/threading/SimulatorNode.java
@@ -65,10 +65,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
-
-import org.orekit.bodies.GeodeticPoint;
-import org.orekit.errors.OrekitException;
-
 import opssat.simulator.GPS;
 import opssat.simulator.Orbit;
 import opssat.simulator.celestia.CelestiaData;
@@ -104,6 +100,8 @@ import opssat.simulator.util.SimulatorSpacecraftState;
 import opssat.simulator.util.SimulatorTimer;
 import org.hipparchus.geometry.euclidean.threed.Vector3D;
 import static org.hipparchus.util.FastMath.toDegrees;
+import org.orekit.bodies.GeodeticPoint;
+import org.orekit.errors.OrekitException;
 import org.orekit.propagation.analytical.tle.TLE;
 
 /**
@@ -176,6 +174,11 @@ public class SimulatorNode extends TaskNode
       + File.separator;
   private final static String OPS_SAT_SIMULATOR_RESOURCES = OPS_SAT_SIMULATOR_DATA + "resources"
       + File.separator;
+
+  private final static String OPSSAT_TLE_LINE1 =
+      "1 44878U 19092F   20159.72929773  .00000725  00000-0  41750-4 0  9990";
+  private final static String OPSSAT_TLE_LINE2 =
+      "2 44878  97.4685 343.1680 0015119  36.0805 324.1445 15.15469997 26069";
 
   // Platform sim properties
   private Properties platformProperties;
@@ -291,8 +294,13 @@ public class SimulatorNode extends TaskNode
    */
   public TLE getTLE()
   {
-    return this.orekitCore.getTLE();
-
+    if (this.simulatorHeader.isUseOrekitPropagator()) {
+      return this.orekitCore.getTLE();
+    } else {
+      Logger.getLogger(SimulatorNode.class.getCanonicalName()).log(Level.WARNING,
+          "TLE only awailable in Simulator, wenn Using Orekit propagator!");
+      return new TLE(OPSSAT_TLE_LINE1, OPSSAT_TLE_LINE2);
+    }
   }
 
   public enum DevDatPBind


### PR DESCRIPTION
Fixes error which occurred when calling get TLE while Orekit propagator was disabled. Now returns a default TLE (all Positional values zero)