### PR TITLE
docs/source/sdk: s/apps our ground/apps and ground/

### DIFF
--- a/docs/source/sdk.rst
+++ b/docs/source/sdk.rst
@@ -1,7 +1,7 @@
 ===
 SDK
 ===
-The SDK provides basic functionality to develop and test your space apps our ground applications. The SDK is located is the **sdk/** folder of the repository. 
+The SDK provides basic functionality to develop and test your space apps and ground applications. The SDK is located is the **sdk/** folder of the repository. 
 To build the SDK you can just run ``mvn install`` in the **sdk/** directory. This will build all examples and package them into a release zip and folder which you can find under **sdk/sdk-package/target/**.
 
 .. contents:: Table of Contents


### PR DESCRIPTION
This fixes a small typo in the documentation for [getting started with the SDK](https://nanosat-mo-framework.readthedocs.io/en/latest/sdk.html).

**Before:**

<img width="698" alt="image" src="https://user-images.githubusercontent.com/1130872/86537945-376d0780-bee2-11ea-80f0-55d332d889ab.png">

**After:**

<img width="701" alt="image" src="https://user-images.githubusercontent.com/1130872/86537954-4d7ac800-bee2-11ea-86fe-50ab94f2c64a.png">

Note: The text above was only highlighted to denote the change, when taking the screenshots. It's not part of the pull request.