### PR TITLE
Feature #949 Add selection of attitude determination mode

### DIFF
--- a/core/mo-services-xml/src/main/resources/xml/ServiceDefPLATFORM.xml
+++ b/core/mo-services-xml/src/main/resources/xml/ServiceDefPLATFORM.xml
@@ -1511,6 +1511,12 @@
           <mal:extends>
             <mal:type area="MAL" list="false" name="Composite" />
           </mal:extends>
+          <mal:field canBeNull="true"
+            comment="Commanded attitude determination mode."
+            name="attitudeDeterminationMode">
+            <mal:type area="Platform" list="false"
+              name="AttitudeDeterminationMode" service="AutonomousADCS" />
+          </mal:field>
         </mal:composite>
         <mal:composite
           comment="B-dot detumbling attitude mode defined by the consumer."
@@ -1606,6 +1612,14 @@
         <mal:composite
           comment="Nadir Pointing attitude mode defined by the consumer."
           name="AttitudeModeNadirPointing" shortFormPart="7">
+          <mal:extends>
+            <mal:type area="Platform" list="false"
+                      name="AttitudeMode" service="AutonomousADCS" />
+          </mal:extends>
+        </mal:composite>
+        <mal:composite
+          comment="Inertial Pointing attitude mode defined by the consumer."
+          name="AttitudeModeInertialPointing" shortFormPart="25">
           <mal:extends>
             <mal:type area="Platform" list="false"
                       name="AttitudeMode" service="AutonomousADCS" />
@@ -1738,9 +1752,21 @@
           <mal:item comment="Reaction wheel w"
                     nvalue="6" value="WHEEL_W" />
         </mal:enumeration>
+        <mal:enumeration
+          comment="Attitude determination mode identifier."
+          name="AttitudeDeterminationMode" shortFormPart="13">
+          <mal:item comment="Attitude determination using magnetometer and sun sensors"
+                    nvalue="1" value="MGT_SUN" />
+          <mal:item comment="Attitude determination using star tracker with magnetometer and sun sensors"
+                    nvalue="2" value="STRTRK_MGT_SUN" />
+          <mal:item comment="Attitude determination using star tracker only"
+                    nvalue="3" value="STRTRK_ONLY" />
+          <mal:item comment="Attitude determination invalid"
+                    nvalue="4" value="Invalid" />
+        </mal:enumeration>
         <mal:composite
-          comment="Holds Raction wheel parameters" name="ReactionWheelParameters"
-          shortFormPart="12">
+          comment="Holds reaction wheel parameters" name="ReactionWheelParameters"
+          shortFormPart="14">
           <mal:field canBeNull="false"
                      comment="Control mode of the Reaction wheels. 0 = Target value is a current value [A]; 1 = Target value is a speed value [rad/sec]; 2 = Target alue is a torgh [Nm]" name="controlMode">
             <mal:type area="MAL" list="false" name="Integer" />

--- a/sdk/examples/ground/camera-acquisitor-system-ground/src/main/java/esa/mo/ground/cameraacquisotorground/CameraAcquisitorGround.java
+++ b/sdk/examples/ground/camera-acquisitor-system-ground/src/main/java/esa/mo/ground/cameraacquisotorground/CameraAcquisitorGround.java
@@ -297,17 +297,17 @@ public class CameraAcquisitorGround
    *
    * @param longitude longitude of the target location.
    * @param latitude  latitude of the target location.
-   * @param timeStemp time at which the photograph should be taken.
+   * @param timeStamp time at which the photograph should be taken.
    * @return the actionID that was assigned to space application action.
    */
   @PostMapping("/schedulePhotographPosition")
   public Long schedulePhotographPosition(
       @RequestParam(value = "longitude") double longitude,
       @RequestParam(value = "latitude") double latitude,
-      @RequestParam(value = "timeStemp") String timeStemp)
+      @RequestParam(value = "timeStamp") String timeStamp)
   {
 
-    AbsoluteDate scheduleDate = new AbsoluteDate(timeStemp, TimeScalesFactory.getUTC());
+    AbsoluteDate scheduleDate = new AbsoluteDate(timeStamp, TimeScalesFactory.getUTC());
 
     // check if timeslot is awailable
     if (checkTimeSlot(scheduleDate)) {
@@ -329,7 +329,7 @@ public class CameraAcquisitorGround
         AttributeValueList arguments = new AttributeValueList();
         arguments.add(new AttributeValue((Attribute) HelperAttributes.javaType2Attribute(latitude)));
         arguments.add(new AttributeValue((Attribute) HelperAttributes.javaType2Attribute(longitude)));
-        arguments.add(new AttributeValue((Attribute) HelperAttributes.javaType2Attribute(timeStemp)));
+        arguments.add(new AttributeValue((Attribute) HelperAttributes.javaType2Attribute(timeStamp)));
 
         Long actionID = gma.invokeAction(objIds.get(0).getObjDefInstanceId(), arguments);
         if (actionID == null) {

--- a/sdk/examples/space/camera-acquisitor-system/src/main/java/esa/mo/nmf/apps/CameraAcquisitorSystemCameraTargetHandler.java
+++ b/sdk/examples/space/camera-acquisitor-system/src/main/java/esa/mo/nmf/apps/CameraAcquisitorSystemCameraTargetHandler.java
@@ -48,6 +48,7 @@ import org.ccsds.moims.mo.platform.autonomousadcs.structures.AttitudeMode;
 import org.ccsds.moims.mo.platform.autonomousadcs.structures.AttitudeModeTargetTracking;
 import org.orekit.time.AbsoluteDate;
 import org.orekit.time.TimeScalesFactory;
+import org.ccsds.moims.mo.platform.autonomousadcs.structures.AttitudeDeterminationMode;
 
 /**
  * Class handling acquisition of targets and the corresponding actions
@@ -80,24 +81,24 @@ public class CameraAcquisitorSystemCameraTargetHandler
   UInteger photographLocation(
       AttributeValueList attributeValues,
       Long actionInstanceObjId,
-      boolean reportProgress, MALInteraction interaction)
+      boolean reportProgress, MALInteraction interaction, AttitudeDeterminationMode determinationMode)
   {
     // get parameters
     Double longitude = HelperAttributes.attribute2double(attributeValues.get(0).getValue());
     Double latitude = HelperAttributes.attribute2double(attributeValues.get(1).getValue());
-    String timeStemp =
+    String timeStamp =
         HelperAttributes.attribute2JavaType(attributeValues.get(2).getValue()).toString();
     //
     return photographLocation(
-        longitude, latitude, timeStemp, actionInstanceObjId, reportProgress, interaction);
+        longitude, latitude, timeStamp, actionInstanceObjId, reportProgress, interaction, determinationMode);
   }
 
 
-  UInteger photographLocation(double longitude, double latitude, String timeStemp,
+  UInteger photographLocation(double longitude, double latitude, String timeStamp,
       Long actionInstanceObjId,
-      boolean reportProgress, MALInteraction interaction)
+      boolean reportProgress, MALInteraction interaction, AttitudeDeterminationMode determinationMode)
   {
-    AbsoluteDate targetDate = new AbsoluteDate(timeStemp, TimeScalesFactory.getUTC());
+    AbsoluteDate targetDate = new AbsoluteDate(timeStamp, TimeScalesFactory.getUTC());
 
     double seconds = targetDate.durationFrom(CameraAcquisitorSystemMCAdapter.getNow());
 
@@ -122,7 +123,7 @@ public class CameraAcquisitorSystemCameraTargetHandler
             targetDate.durationFrom(CameraAcquisitorSystemMCAdapter.getNow()));
 
         // set desired attitude using target latitude and longitude
-        AttitudeMode desiredAttitude = new AttitudeModeTargetTracking(
+        AttitudeMode desiredAttitude = new AttitudeModeTargetTracking(determinationMode,
             (float) longitude,
             (float) latitude);
 
@@ -257,9 +258,9 @@ public class CameraAcquisitorSystemCameraTargetHandler
           if (objBody instanceof ActionInstanceDetails) {
             ActionInstanceDetails instance = ((ActionInstanceDetails) objBody);
             if (instance.getArgumentValues().size() == 3) {
-              String timeStemp = instance.getArgumentValues().get(2).getValue().toString();
+              String timeStamp = instance.getArgumentValues().get(2).getValue().toString();
               try {
-                AbsoluteDate targetDate = new AbsoluteDate(timeStemp, TimeScalesFactory.getUTC());
+                AbsoluteDate targetDate = new AbsoluteDate(timeStamp, TimeScalesFactory.getUTC());
 
                 if (targetDate.compareTo(CameraAcquisitorSystemMCAdapter.getNow()) > 0) {
                   photographLocation(instance.getArgumentValues(), objDetails.get(
@@ -267,7 +268,7 @@ public class CameraAcquisitorSystemCameraTargetHandler
                       null);
                   Logger.getLogger(CameraAcquisitorSystemCameraTargetHandler.class.getName()).log(
                       Level.INFO, "recovered action: {0} longitude:{1} latitude:{2}", new Object[]{
-                        timeStemp,
+                        timeStamp,
                         instance.getArgumentValues().get(0).getValue().toString(),
                         instance.getArgumentValues().get(
                             2).getValue().toString()});

--- a/sdk/examples/space/camera-acquisitor-system/src/main/java/esa/mo/nmf/apps/CameraAcquisitorSystemMCAdapter.java
+++ b/sdk/examples/space/camera-acquisitor-system/src/main/java/esa/mo/nmf/apps/CameraAcquisitorSystemMCAdapter.java
@@ -33,6 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.ccsds.moims.mo.mal.provider.MALInteraction;
 import org.ccsds.moims.mo.mal.structures.UInteger;
+import org.ccsds.moims.mo.platform.autonomousadcs.structures.AttitudeDeterminationMode;
 import org.ccsds.moims.mo.platform.camera.structures.PictureFormat;
 import org.orekit.data.DataProvidersManager;
 import org.orekit.errors.OrekitException;
@@ -113,7 +114,17 @@ public class CameraAcquisitorSystemMCAdapter extends MonitorAndControlNMFAdapter
       generationEnabled = false)
   private int pictureType = 3;
 
+  @Parameter(description =
+      "The attitude determination mode to select (_MGT_SUN_INDEX = 0, _STRTRK_MGT_SUN_INDEX = 1, _STRTRK_ONLY_INDEX = 2, _Invalid_INDEX = 3)",
+      generationEnabled = false)
+  private AttitudeDeterminationMode determinationMode;
+
   // ----------------------------------------------------------------------------------------------
+  public AttitudeDeterminationMode getDeterminationMode()
+  {
+    return determinationMode;
+  }
+  
   public PictureFormat getPictureType()
   {
     return PictureFormat.fromOrdinal(pictureType);
@@ -206,7 +217,7 @@ public class CameraAcquisitorSystemMCAdapter extends MonitorAndControlNMFAdapter
   }
 
   @Action(
-      description = "queues a new photograph target at the Specified Timestemp",
+      description = "queues a new photograph target at the Specified timeStamp",
       stepCount = CameraAcquisitorSystemCameraTargetHandler.PHOTOGRAPH_LOCATION_STAGES,
       name = CameraAcquisitorSystemCameraTargetHandler.ACTION_PHOTOGRAPH_LOCATION)
   public UInteger photographLocation(
@@ -215,12 +226,12 @@ public class CameraAcquisitorSystemMCAdapter extends MonitorAndControlNMFAdapter
       MALInteraction interaction,
       @ActionParameter(name = "targetLongitude", rawUnit = "degree") Double targetLongitude,
       @ActionParameter(name = "targetLatitude", rawUnit = "degree") Double targetLatitude,
-      @ActionParameter(name = "timeStemp") String timeStemp)
+      @ActionParameter(name = "timeStamp") String timeStamp, AttitudeDeterminationMode determinationMode)
   {
     Logger.getLogger(CameraAcquisitorSystemMCAdapter.class.getName()).log(Level.SEVERE,
-        "" + targetLongitude + " " + targetLatitude + " " + timeStemp);
-    return this.cameraTargetHandler.photographLocation(targetLongitude, targetLatitude, timeStemp,
-        actionInstanceObjId, reportProgress, interaction);
+        "" + targetLongitude + " " + targetLatitude + " " + timeStamp);
+    return this.cameraTargetHandler.photographLocation(targetLongitude, targetLatitude, timeStamp,
+        actionInstanceObjId, reportProgress, interaction, determinationMode);
   }
 
   @Action(

--- a/sdk/examples/space/payloads-test/src/main/java/esa/mo/nmf/apps/PayloadsTestMCAdapter.java
+++ b/sdk/examples/space/payloads-test/src/main/java/esa/mo/nmf/apps/PayloadsTestMCAdapter.java
@@ -61,6 +61,7 @@ import org.ccsds.moims.mo.mc.structures.ConditionalConversionList;
 import org.ccsds.moims.mo.mc.structures.ParameterExpression;
 import org.ccsds.moims.mo.platform.autonomousadcs.consumer.AutonomousADCSAdapter;
 import org.ccsds.moims.mo.platform.autonomousadcs.structures.*;
+import org.ccsds.moims.mo.platform.autonomousadcs.structures.factory.AttitudeDeterminationModeFactory;
 import org.ccsds.moims.mo.platform.camera.structures.PictureFormat;
 import org.ccsds.moims.mo.platform.camera.structures.PixelResolution;
 import org.ccsds.moims.mo.platform.gps.consumer.GPSAdapter;
@@ -511,7 +512,7 @@ public class PayloadsTestMCAdapter extends MonitorAndControlNMFAdapter
       @ActionParameter(name = "margin", rawUnit = "degree") float margin)
   {
     return actionsHandler.executeAdcsModeAction(holdDuration,
-        new AttitudeModeVectorPointing(new VectorF3D(x, y, z), new Float(margin)), this);
+        new AttitudeModeVectorPointing(new AttitudeDeterminationModeFactory(), new VectorF3D(x, y, z), new Float(margin)), this);
   }
 
   @Action(description = "Unsets the spacecraft's attitude.")


### PR DESCRIPTION
As suggested by Reinhard, the user can now select the attitude determination mode via an added MAL enum struct which is then translated to the API SEPP_IADCS_API_TARGET_POINTING_ATTITUDE_DETERMINATION_MODES.