### PR TITLE
fix: archive sync domain encoding used wrong format

### DIFF
--- a/core/mo-services-impl/ccsds-com-impl/src/main/java/esa/mo/com/impl/sync/EncodeDecode.java
+++ b/core/mo-services-impl/ccsds-com-impl/src/main/java/esa/mo/com/impl/sync/EncodeDecode.java
@@ -50,11 +50,20 @@ import org.ccsds.moims.mo.mal.structures.StringList;
 import org.ccsds.moims.mo.mal.structures.URI;
 
 /**
+ * Encodes and decodes COM objects to and from bytes.
  *
  * @author Cesar Coelho
  */
 public class EncodeDecode {
 
+    /**
+     * Encodes a database COM object to byte array.
+     *
+     * @param entity The object to encode
+     * @param manager The archive manager for fast object details retrieval
+     * @param dictionary Dictionary mapping strings to integers
+     * @return The byte array holding the encoded COM object
+     */
     public static byte[] encodeToByteArray(final COMObjectEntity entity,
             ArchiveManager manager, Dictionary dictionary) {
         try {
@@ -117,6 +126,15 @@ public class EncodeDecode {
         return new byte[0]; // Return an empty byte array
     }
 
+    /**
+     * Decodes a list of COM objects from a list of byte arrays.
+     *
+     * @param chunks The list of byte arrays
+     * @param dictionary Local dictionary mapping integers to strings
+     * @param archiveSyncService ArchiveSync provider to fetch strings missing in the local dictionary
+     * @param domain The domain of the COM objects to decode
+     * @return The list of decoded COM objects
+     */
     public static ArrayList<COMObjectStructure> decodeFromByteArrayList(ArrayList<byte[]> chunks,
             Dictionary dictionary, ArchiveSyncStub archiveSyncService, IdentifierList domain) {
         ArrayList<COMObjectStructure> objs = new ArrayList<COMObjectStructure>();

--- a/core/mo-services-impl/ccsds-com-impl/src/main/java/esa/mo/com/impl/sync/EncodeDecode.java
+++ b/core/mo-services-impl/ccsds-com-impl/src/main/java/esa/mo/com/impl/sync/EncodeDecode.java
@@ -77,7 +77,7 @@ public class EncodeDecode {
                 be.encodeNullableShort(null);
             } else {
                 IdentifierList sourceDomain = manager.getFastDomain().getDomain(entity.getSourceLink().getDomainId());
-                Integer wordId3 = dictionary.getWordId(sourceDomain.toString());
+                Integer wordId3 = dictionary.getWordId(HelperMisc.domain2domainId(sourceDomain));
                 be.encodeNullableShort(wordId3.shortValue());
             }
 


### PR DESCRIPTION
@CesarCoelho could you please confirm?

When parsing the COM archive file that @dmarszk provided me with my new tool:
 - I found that the domain in the `COM`  `ObjectKey` of the `ObjectId` in `ObjectDetails` objects, was wrongly formatted as follow:
     - `"[esa, nanosat-mo-supervisor]"` instead of `["esa", "nanosat-mo-supervisor"]`
 - Considering that when you decode [here](https://github.com/esa/nanosat-mo-framework/blob/f761a58ec3c42fe46bd8836db2b64399849366c5/core/mo-services-impl/ccsds-com-impl/src/main/java/esa/mo/com/impl/sync/EncodeDecode.java#L211) you use the reversed function, I believe we need this fix