### PR TITLE
Bug #1067 [supervisor] Reduce memory usage

### DIFF
--- a/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/MCSupervisorBasicAdapter.java
+++ b/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/MCSupervisorBasicAdapter.java
@@ -27,7 +27,10 @@ import java.util.Date;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.xml.bind.JAXBException;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
+
 import org.ccsds.moims.mo.mal.MALException;
 import org.ccsds.moims.mo.mal.MALInteractionException;
 import org.ccsds.moims.mo.mal.MALStandardError;
@@ -113,7 +116,7 @@ public class MCSupervisorBasicAdapter extends MonitorAndControlNMFAdapter {
       obswParameterManager =
           new OBSWParameterManager(getClass().getClassLoader().getResourceAsStream("Datapool.xml"));
       obswParameterManager.registerParametersProxies(registrationObject);
-    } catch (ParserConfigurationException | SAXException | IOException e) {
+    } catch (ParserConfigurationException | SAXException | IOException | JAXBException | XMLStreamException e) {
       LOGGER.log(Level.SEVERE, "Couldn't register OBSW parameters proxies", e);
     }
   }

--- a/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/parameter/OBSWParameter.java
+++ b/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/parameter/OBSWParameter.java
@@ -20,35 +20,46 @@
  */
 package esa.mo.nmf.nanosatmosupervisor.parameter;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
 /**
  * Holds the information for an OBSW parameter defined in the datapool XML file.
  *
  * @author Tanguy Soto
  */
+@XmlAccessorType(XmlAccessType.FIELD)
 public class OBSWParameter {
   /**
    * Parameter ID (object instance id of the ParameterIdentity).
    */
+  @XmlAttribute
   private final Long id;
 
   /**
    * Parameter name (Identifier, body of the ParameterIdentity)
    */
+  @XmlAttribute
   private final String name;
 
   /**
    * Parameter description (description field of the ParameterDefinitionDetails)
    */
+  @XmlAttribute
   private final String description;
 
   /**
    * Parameter type (rawType field of the ParameterDefinitionDetails)
    */
+  @XmlAttribute(name = "attributeType")
   private final String type;
 
   /**
    * Parameter unit (rawUnit field of the ParameterDefinitionDetails)
    */
+  @XmlAttribute
   private final String unit;
 
   /**
@@ -56,9 +67,18 @@ public class OBSWParameter {
    */
   private OBSWAggregation aggregation;
 
+  public OBSWParameter() {
+    super();
+    this.id = null;
+    this.name = null;
+    this.description = null;
+    this.type = null;
+    this.unit = null;
+  }
+
   /**
    * Creates a new instance of OBSWParameter.
-   * 
+   *
    * @param id
    * @param name
    * @param description

--- a/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/parameter/OBSWParameterManager.java
+++ b/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/parameter/OBSWParameterManager.java
@@ -29,7 +29,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.xml.bind.JAXBException;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
+
 import org.ccsds.moims.mo.mal.structures.Attribute;
 import org.ccsds.moims.mo.mal.structures.Duration;
 import org.ccsds.moims.mo.mal.structures.Identifier;
@@ -74,7 +77,7 @@ public class OBSWParameterManager {
   private OBSWParameterValuesProvider valuesProvider;
 
   public OBSWParameterManager(InputStream datapool)
-      throws ParserConfigurationException, SAXException, IOException {
+          throws ParserConfigurationException, SAXException, IOException, JAXBException, XMLStreamException {
     // Read from provided inputstreams
     parameterLister = new ParameterLister(datapool);
 


### PR DESCRIPTION
When loading parameters from xml, avoid loading the
whole file into memory by using the SAX parser instead.
In simulator, instead of reading file lines into array,
process them on the go.