### PR TITLE
Bug #985 Deregister subscriptions

### DIFF
--- a/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/services/mc/AggregationConsumerPanel.java
+++ b/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/services/mc/AggregationConsumerPanel.java
@@ -67,6 +67,7 @@ public class AggregationConsumerPanel extends javax.swing.JPanel {
 
     private final AggregationConsumerServiceImpl serviceMCAggregation;
     private final AggregationTablePanel aggregationTable;
+    private Subscription subscription;
 
     /**
      *
@@ -84,13 +85,26 @@ public class AggregationConsumerPanel extends javax.swing.JPanel {
         this.listDefinitionAllButtonActionPerformed(null);
 
         // Subscribe to ParametersValues
-        Subscription subscription = ConnectionConsumer.subscriptionWildcard();
+        subscription = ConnectionConsumer.subscriptionWildcard();
         try {
             serviceMCAggregation.getAggregationStub().monitorValueRegister(subscription, new AggregationConsumerAdapter());
         } catch (MALInteractionException | MALException ex) {
             Logger.getLogger(AggregationConsumerPanel.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
+
+    public void removeNotify()
+    {
+        super.removeNotify();
+        IdentifierList ids = new IdentifierList();
+        ids.add(subscription.getSubscriptionId());
+        try {
+            serviceMCAggregation.getAggregationStub().monitorValueDeregister(ids);
+        } catch (MALInteractionException | MALException ex) {
+            Logger.getLogger(AggregationConsumerPanel.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
 
     /**
      * This method is called from within the constructor to initialize the

--- a/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/services/mc/ParameterPublishedValues.java
+++ b/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/services/mc/ParameterPublishedValues.java
@@ -31,6 +31,7 @@ import org.ccsds.moims.mo.com.structures.ObjectIdList;
 import org.ccsds.moims.mo.mal.MALException;
 import org.ccsds.moims.mo.mal.MALInteractionException;
 import org.ccsds.moims.mo.mal.structures.Identifier;
+import org.ccsds.moims.mo.mal.structures.IdentifierList;
 import org.ccsds.moims.mo.mal.structures.Subscription;
 import org.ccsds.moims.mo.mal.structures.UInteger;
 import org.ccsds.moims.mo.mal.structures.UOctet;
@@ -51,6 +52,7 @@ public class ParameterPublishedValues extends javax.swing.JPanel {
     final ParameterConsumerServiceImpl parameterService;
     private final int numberOfColumns = 5;
     private final ParameterLabel[] labels = new ParameterLabel[32 * numberOfColumns];
+    private Subscription subscription;
 
     public ParameterLabel[] getLabels() {
         return this.labels;
@@ -87,8 +89,20 @@ public class ParameterPublishedValues extends javax.swing.JPanel {
 
     public void subscribeToParameters() throws MALInteractionException, MALException {
         // Subscribe to ParametersValues
-        final Subscription subscription = ConnectionConsumer.subscriptionWildcard();
+        subscription = ConnectionConsumer.subscriptionWildcard();
         this.parameterService.getParameterStub().monitorValueRegister(subscription, new ParameterConsumerAdapter());
+    }
+
+    public void removeNotify()
+    {
+        super.removeNotify();
+        IdentifierList ids = new IdentifierList();
+        ids.add(subscription.getSubscriptionId());
+        try {
+            parameterService.getParameterStub().monitorValueDeregister(ids);
+        } catch (MALInteractionException | MALException ex) {
+            Logger.getLogger(ParameterPublishedValues.class.getName()).log(Level.SEVERE, null, ex);
+        }
     }
 
     public class ParameterConsumerAdapter extends ParameterAdapter {

--- a/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/services/mc/StatisticConsumerPanel.java
+++ b/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/services/mc/StatisticConsumerPanel.java
@@ -40,6 +40,7 @@ import org.ccsds.moims.mo.mal.MALException;
 import org.ccsds.moims.mo.mal.MALInteractionException;
 import org.ccsds.moims.mo.mal.structures.Duration;
 import org.ccsds.moims.mo.mal.structures.Identifier;
+import org.ccsds.moims.mo.mal.structures.IdentifierList;
 import org.ccsds.moims.mo.mal.structures.LongList;
 import org.ccsds.moims.mo.mal.structures.Subscription;
 import org.ccsds.moims.mo.mal.structures.UpdateHeader;
@@ -61,6 +62,7 @@ import org.ccsds.moims.mo.mc.structures.ObjectInstancePairList;
  */
 public class StatisticConsumerPanel extends javax.swing.JPanel {
 
+    private final Subscription subscription;
     private StatisticConsumerServiceImpl serviceMCStatistic;
     private ParameterConsumerServiceImpl serviceMCParameter;
     private StatisticLinkTablePanel statisticTable;
@@ -83,13 +85,25 @@ public class StatisticConsumerPanel extends javax.swing.JPanel {
 
     
         // Subscribe to Statistic Values
-        Subscription subscription = ConnectionConsumer.subscriptionWildcard();
+        subscription = ConnectionConsumer.subscriptionWildcard();
         try {
             serviceMCStatistic.getStatisticStub().monitorStatisticsRegister(subscription, new StatisticConsumerAdapter());
         } catch (MALInteractionException | MALException ex) {
             Logger.getLogger(StatisticConsumerPanel.class.getName()).log(Level.SEVERE, null, ex);
         }
 
+    }
+
+    public void removeNotify()
+    {
+        super.removeNotify();
+        IdentifierList ids = new IdentifierList();
+        ids.add(subscription.getSubscriptionId());
+        try {
+            serviceMCStatistic.getStatisticStub().monitorStatisticsDeregister(ids);
+        } catch (MALInteractionException | MALException ex) {
+            Logger.getLogger(StatisticConsumerPanel.class.getName()).log(Level.SEVERE, null, ex);
+        }
     }
 
     /**

--- a/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/services/sm/AppsLauncherConsumerPanel.java
+++ b/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/services/sm/AppsLauncherConsumerPanel.java
@@ -53,6 +53,7 @@ public class AppsLauncherConsumerPanel extends javax.swing.JPanel
   private final AppsLauncherConsumerServiceImpl serviceSMAppsLauncher;
   private AppsLauncherTablePanel appsTable;
   private final HashMap<Long, StringBuffer> outputBuffers = new HashMap<>();
+  private Subscription subscription;
 
   /**
    *
@@ -110,10 +111,22 @@ public class AppsLauncherConsumerPanel extends javax.swing.JPanel
     this.listAppAllButtonActionPerformed(null);
 
     // Subscribe to Apps
-    Subscription subscription = ConnectionConsumer.subscriptionWildcard();
+    subscription = ConnectionConsumer.subscriptionWildcard();
     try {
       serviceSMAppsLauncher.getAppsLauncherStub().monitorExecutionRegister(subscription,
           new AppsLauncherConsumerAdapter());
+    } catch (MALInteractionException | MALException ex) {
+      LOGGER.log(Level.SEVERE, null, ex);
+    }
+  }
+
+  public void removeNotify()
+  {
+    super.removeNotify();
+    IdentifierList ids = new IdentifierList();
+    ids.add(subscription.getSubscriptionId());
+    try {
+      serviceSMAppsLauncher.getAppsLauncherStub().monitorExecutionDeregister(ids);
     } catch (MALInteractionException | MALException ex) {
       LOGGER.log(Level.SEVERE, null, ex);
     }


### PR DESCRIPTION
CTT Panels subscribe to some parameters by default,
when tab is closed, deregister these subscriptions.