### PR TITLE
Bug #985 Deregister subscriptions

### DIFF
--- a/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/guis/ConsumerTestToolGUI.java
+++ b/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/guis/ConsumerTestToolGUI.java
@@ -138,6 +138,14 @@ public class ConsumerTestToolGUI extends javax.swing.JFrame
         tabs = new javax.swing.JTabbedPane();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        addWindowListener(new java.awt.event.WindowAdapter() {
+          @Override
+          public void windowClosing(java.awt.event.WindowEvent e) {
+              // call dispose here, so on panels the removeNotify is also called
+              // to clean up the connections
+              e.getWindow().dispose();
+          }
+        });
         setMinimumSize(new java.awt.Dimension(800, 600));
         setName("Form"); // NOI18N
         setPreferredSize(new java.awt.Dimension(1100, 600));

--- a/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/utils/ProviderTabPanel.java
+++ b/sdk/tools/consumer-test-tool/src/main/java/esa/mo/nmf/ctt/utils/ProviderTabPanel.java
@@ -317,4 +317,10 @@ public class ProviderTabPanel extends javax.swing.JPanel {
             );
         }
     }
+
+    @Override
+    public void removeNotify() {
+        super.removeNotify();
+        getServices().closeConnections();
+    }
 }


### PR DESCRIPTION
One more case regarding bug #985.

Close connections when CTT exits.
A test case where CTT exists and is restarted soon after.
Previously was causing warnings to flood the new CTT log.