### PR TITLE
[Simulator] Minor improvements

### DIFF
--- a/core/misc/mal-elements-window/src/main/java/esa/mo/tools/mowindow/MOWindow.java
+++ b/core/misc/mal-elements-window/src/main/java/esa/mo/tools/mowindow/MOWindow.java
@@ -258,7 +258,7 @@ public final class MOWindow extends javax.swing.JDialog {
         button = new javax.swing.JToggleButton();
 
         setMinimumSize(new java.awt.Dimension(600, 120));
-        setResizable(false);
+        setResizable(true);
         addWindowListener(new java.awt.event.WindowAdapter() {
             public void windowClosed(java.awt.event.WindowEvent evt) {
                 formWindowClosed(evt);

--- a/core/nmf-composites/generic-composite-model/src/main/java/esa/mo/nmf/MonitorAndControlNMFAdapter.java
+++ b/core/nmf-composites/generic-composite-model/src/main/java/esa/mo/nmf/MonitorAndControlNMFAdapter.java
@@ -430,7 +430,8 @@ public abstract class MonitorAndControlNMFAdapter implements ActionInvocationLis
           "Arguments for action are incorrect! {0}", ex.getMessage());
     } catch (InvocationTargetException ex) {
       Logger.getLogger(MonitorAndControlNMFAdapter.class.getName()).log(Level.SEVERE,
-          "The action Method threw an exception! {0}", ex.getMessage());
+          "The action Method threw an invocation exception! {0}", (ex.getMessage() != null ? ex.getMessage() :
+                      ex.getTargetException().getMessage()));
     }
     return new UInteger(0);
   }


### PR DESCRIPTION
Make the dialogs resizable.
Clarify the InvocationTargetException reason
by exposing the underlying message (eg when
the input for photographLocation action in
camera acquisitor app are not correct).