### PR TITLE
[bug] re-add COM Archive Tool to the SDK packaging

### DIFF
--- a/sdk/sdk-package/antpkg/build.xml
+++ b/sdk/sdk-package/antpkg/build.xml
@@ -1,7 +1,7 @@
 <project name="SDK Package" default="build" basedir="../../">
   <property name="outputDir" value="${esa.nmf.sdk.assembly.outputdir}/home"/>
   <property name="repoName" value="nmf/lib"/>
-  <target name="build" depends="emit-ctt, emit-simulator-gui, emit-space-supervisor, emit-space-app-all-mc-services,
+  <target name="build" depends="emit-ctt, emit-com-archive-tool, emit-simulator-gui, emit-space-supervisor, emit-space-app-all-mc-services,
   emit-space-app-publish-clock, emit-space-app-camera, emit-space-app-benchmark, emit-space-app-payloads-test,
   emit-space-app-waveform, emit-space-app-camera-acquisitor-system, emit-space-app-picture-processor,
   emit-space-app-mp-demo, emit-ground-app-mp-demo">

--- a/sdk/tools/com-archive-tool/README.md
+++ b/sdk/tools/com-archive-tool/README.md
@@ -1,6 +1,6 @@
-LOG Browser
+COM Archive Tool
 ===========
-CLI tool to browse a COM archive to retrieve logs and more from it.
+Browses a COM archive to retrieve it's contents from the command line.
 
 # Usage
 
@@ -13,12 +13,13 @@ Starting it with `-h` or `--help` like so:
 Will display the following help message:
 
 ```
-Usage: LogBrowser [-h] [COMMAND]
-Browses a COM archive to retrieve logs and more from it.
+Usage: COMArchiveTool [-h] [COMMAND]
+Browses a COM archive to retrieve it's contents.
   -h, --help   display a help message
 Commands:
-  dump_raw  Dumps to a JSON file the raw tables content of a local COM archive
-  dump      Dumps to a JSON file the formatted content of a local or remote COM archive
-  log       Gets or lists NMF app logs using the content of a local or remote COM archive.
-  list      Lists the COM archive providers URIs found in a central directory
+  log        Gets or lists NMF app logs using the content of a local or remote COM archive.
+  parameter  Gets or lists NMF app parameters using the content of a local or remote COM archive.
+  dump_raw   Dumps to a JSON file the raw tables content of a local COM archive
+  dump       Dumps to a JSON file the formatted content of a local or remote COM archive
+  list       Lists the COM archive providers URIs found in a central directory
 ```

--- a/sdk/tools/com-archive-tool/pom.xml
+++ b/sdk/tools/com-archive-tool/pom.xml
@@ -26,8 +26,8 @@
   <artifactId>com-archive-tool</artifactId>
   <packaging>jar</packaging>
 
-  <name>ESA NMF SDK Tool - COM Archive Browser</name>
-  <description>An MO COM Archive Consumer providing NMF Apps archive contents through command line</description>
+  <name>ESA NMF SDK Tool - COM Archive Tool</name>
+  <description>Browses a COM archive to retrieve it's contents from the command line.</description>
   <url>http://www.esa.int</url>
 
   <organization>

--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/parameters/ParametersCommandsDefinitions.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/parameters/ParametersCommandsDefinitions.java
@@ -36,14 +36,14 @@ import java.util.List;
 public class ParametersCommandsDefinitions {
 
     @Command(name = "parameter", subcommands = {ListParameters.class, GetParameters.class},
-            description = "Gets or lists NMF app parameters using the content of a local or remote COM archive.")
+            description = "Gets or lists MO parameters using the content of a local or remote COM archive.")
     public static class Parameter {
         @Option(names = {"-h", "--help"}, usageHelp = true, description = "display a help message")
         boolean helpRequested;
     }
 
     @Command(name = "list",
-            description = "Lists available parameters in an NMF app.")
+            description = "Lists available parameters in a COM archive.")
     public static class ListParameters implements Runnable {
         @Option(names = {"-h", "--help"}, usageHelp = true, description = "display a help message")
         boolean helpRequested;
@@ -59,7 +59,7 @@ public class ParametersCommandsDefinitions {
     }
 
     @Command(name = "get",
-            description = "Dumps to a file all parameter samples from an NMF app.")
+            description = "Dumps to a file MO parameters samples from COM archive.")
     public static class GetParameters implements Runnable {
         @Option(names = {"-h", "--help"}, usageHelp = true, description = "display a help message")
         boolean helpRequested;


### PR DESCRIPTION
- the emit rule of the COM Archive Tool disappeared from the SDK packaging build XML file
- update some help messages and the README of the COM Archive Tool