### PR TITLE
Bug #1158 Wrong GPS TIMEA log format in simulator

### DIFF
--- a/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/threading/SimulatorNode.java
+++ b/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/threading/SimulatorNode.java
@@ -3785,6 +3785,7 @@ public class SimulatorNode extends TaskNode
         }
         case 2004: {// Origin [IGPS] Method [String getTIMEASentence();//2004//Obtain UTC time info]
           StringBuilder sb = new StringBuilder(generateOEMHeader("TIMEA", "FINESTEERING"));
+          sb.append("VALID,");
           sb.append("0,0,0,");
           String utc = Instant.now().toString();
           String[] yearTime = utc.split("T");
@@ -3799,7 +3800,7 @@ public class SimulatorNode extends TaskNode
           String hour = hms[0];
           String minute = hms[1];
           String ms = hms[2];
-          ms = ms.replace("\\.", "");
+          ms = ms.replaceAll("\\.", "");
           ms = ms.replace("Z", "");
           sb.append(year).append(",").append(month).append(",");
           sb.append(day).append(",").append(hour).append(",").append(minute).append(",");

--- a/mission/simulator/platform-services-impl/src/test/java/esa/nmf/test/GPSSoftSimAdapterTest.java
+++ b/mission/simulator/platform-services-impl/src/test/java/esa/nmf/test/GPSSoftSimAdapterTest.java
@@ -1,0 +1,26 @@
+package esa.nmf.test;
+
+import opssat.simulator.main.ESASimulator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class GPSSoftSimAdapterTest {
+
+    @Test
+    public void testTIMEAFormat() throws IOException {
+        opssat.simulator.main.ESASimulator eSASimulator = new ESASimulator();
+        esa.mo.platform.impl.provider.softsim.PowerControlSoftSimAdapter pcAdapter =
+                new esa.mo.platform.impl.provider.softsim.PowerControlSoftSimAdapter(eSASimulator);
+        esa.mo.platform.impl.provider.softsim.GPSSoftSimAdapter gPSSoftSimAdapter =
+                new esa.mo.platform.impl.provider.softsim.GPSSoftSimAdapter(eSASimulator, pcAdapter);
+        //Expecting something in lines of:
+        //#TIMEA,COM1,0,35.0,FINESTEERING,1337,410010.000,00000000,9924,1984;VALID,0,0,0,2005,8,25,17,53,17000,VALID*e2fc088c
+        String expectedRegex = "#TIMEA,COM1,0,35\\.0,FINESTEERING,\\d{4},\\d{6}\\.\\d{2,3},[0|1]{8},[\\d|\\D]{4},\\d{4}" +
+                ";VALID,0,0,0,\\d{4},\\d{1,2},\\d{1,2},\\d{1,2},\\d{1,2},\\d{5},VALID[\\D|\\d]{9}";
+        String timea = gPSSoftSimAdapter.getTIMEASentence();
+        Assert.assertTrue("Actual was: " +timea, timea.matches(expectedRegex));
+    }
+
+}


### PR DESCRIPTION
TIMEA log format in simulator has been fixed.
 - clock status field after the header was missing
   (after the ';' separator, a "VALID" tag is expected).
 - utc ms field should be a Ulong (range 0-60999) and not
   a float (last value before the final "VALID" tag")
New unit test added to confirm the format.