### PR TITLE
Bug #1157 Wrong GPS time in simulator GNSS logs

### DIFF
--- a/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/util/SimulatorData.java
+++ b/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/util/SimulatorData.java
@@ -87,6 +87,7 @@ public class SimulatorData implements Serializable {
     private boolean timeRunning;
     private boolean simulatorRunning;
     private long currentTimeLong;
+    private long utcOffsetInMillis = -18000;
 
     public void setMethodsExecuted(int methodsExecuted) {
         this.methodsExecuted = methodsExecuted;
@@ -172,6 +173,22 @@ public class SimulatorData implements Serializable {
         DateFormat df = new SimpleDateFormat("hhmm");
         return df.format(currentTime);
     }
+    public String getUTCCurrentHour() {
+        DateFormat df = new SimpleDateFormat("hh");
+        return df.format(currentTime);
+    }
+    public String getUTCCurrentMinute() {
+        DateFormat df = new SimpleDateFormat("mm");
+        return df.format(currentTime);
+    }
+    public String getUTCCurrentSecond() {
+        DateFormat df = new SimpleDateFormat("ss");
+        return df.format(currentTime);
+    }
+    public String getUTCCurrentMillis() {
+        DateFormat df = new SimpleDateFormat("SSS");
+        return df.format(currentTime);
+    }
     public String getCurrentDay() {
         DateFormat df = new SimpleDateFormat("dd");
         return df.format(currentTime);
@@ -183,6 +200,10 @@ public class SimulatorData implements Serializable {
     public String getCurrentYear() {
         DateFormat df = new SimpleDateFormat("yyyy");
         return df.format(currentTime);
+    }
+
+    public long getUtcOffsetInMillis(){
+        return utcOffsetInMillis;
     }
     
 }

--- a/mission/simulator/platform-services-impl/src/test/java/esa/nmf/test/GPSSoftSimAdapterTest.java
+++ b/mission/simulator/platform-services-impl/src/test/java/esa/nmf/test/GPSSoftSimAdapterTest.java
@@ -8,18 +8,34 @@ import java.io.IOException;
 
 public class GPSSoftSimAdapterTest {
 
+    private static opssat.simulator.main.ESASimulator eSASimulator = new ESASimulator();
+
     @Test
     public void testTIMEAFormat() throws IOException {
-        opssat.simulator.main.ESASimulator eSASimulator = new ESASimulator();
         esa.mo.platform.impl.provider.softsim.PowerControlSoftSimAdapter pcAdapter =
                 new esa.mo.platform.impl.provider.softsim.PowerControlSoftSimAdapter(eSASimulator);
         esa.mo.platform.impl.provider.softsim.GPSSoftSimAdapter gPSSoftSimAdapter =
                 new esa.mo.platform.impl.provider.softsim.GPSSoftSimAdapter(eSASimulator, pcAdapter);
         //Expecting something in lines of:
         //#TIMEA,COM1,0,35.0,FINESTEERING,1337,410010.000,00000000,9924,1984;VALID,0,0,0,2005,8,25,17,53,17000,VALID*e2fc088c
-        String expectedRegex = "#TIMEA,COM1,0,35\\.0,FINESTEERING,\\d{4},\\d{6}\\.\\d{2,3},[0|1]{8},[\\d|\\D]{4},\\d{4}" +
-                ";VALID,0,0,0,\\d{4},\\d{1,2},\\d{1,2},\\d{1,2},\\d{1,2},\\d{5},VALID[\\D|\\d]{9}";
+        String expectedRegex = "#TIMEA,COM1,0,35\\.0,FINESTEERING,\\d{4},\\d{6}\\.\\d{1,3},[0|1]{8},[\\d|\\D]{4}," +
+                "\\d{4};VALID,0,0,-?\\d{1,2}\\.\\d{11},\\d{4},\\d{1,2},\\d{1,2},\\d{1,2},\\d{1,2},\\d{5}," +
+                "VALID[\\D|\\d]{9}";
         String timea = gPSSoftSimAdapter.getTIMEASentence();
+        Assert.assertTrue("Actual was: " +timea, timea.matches(expectedRegex));
+    }
+
+    @Test
+    public void testBESTXYZAHeaderFormat() throws IOException {
+        esa.mo.platform.impl.provider.softsim.PowerControlSoftSimAdapter pcAdapter =
+                new esa.mo.platform.impl.provider.softsim.PowerControlSoftSimAdapter(eSASimulator);
+        esa.mo.platform.impl.provider.softsim.GPSSoftSimAdapter gPSSoftSimAdapter =
+                new esa.mo.platform.impl.provider.softsim.GPSSoftSimAdapter(eSASimulator, pcAdapter);
+        //Expecting the BESTXYZ header to be in the lines of:
+        //#BESTXYZA,COM1,0,35.0,FINESTEERING,2177,306117.000,00100000,97b7,2310...
+        String expectedRegex = "^#BESTXYZA,COM1,0,35\\.0,FINESTEERING,\\d{4},\\d{6}\\.\\d{1,3},[0|1]{8}," +
+                "[\\d|\\D]{4},\\d{4}.+";
+        String timea = gPSSoftSimAdapter.getBestXYZSentence();
         Assert.assertTrue("Actual was: " +timea, timea.matches(expectedRegex));
     }
 


### PR DESCRIPTION
Bug #1157 Wrong GPS time in simulator GNSS logs

UTC and GPS difference should be 18seconds.
This should be reported in the relevant message field UTC-offset.
Both times in the TIMEA logs should be aligned to the "simulated" time
not the system time.

Based on the #1158 change.