### PR TITLE
Issue #1077 [GPS] Provide simulated GPS data onboard

### DIFF
--- a/core/helper-tools/src/main/java/esa/mo/helpertools/misc/Const.java
+++ b/core/helper-tools/src/main/java/esa/mo/helpertools/misc/Const.java
@@ -46,4 +46,9 @@ public class Const
   public static final String PLATFORM_IADCS_CACHING_PERIOD = "esa.mo.nmf.platform.iadcs.caching.period";
   public static final String PLATFORM_GNSS_CACHING_PERIOD = "esa.mo.nmf.platform.gnss.caching.period";
   public static final long APP_SHUTDOWN_GUARD_MS = 5000;
+  public static final String PLATFORM_GNSS_FALLBACK_TO_TLE_PROPERTY = "esa.mo.nmf.platform.gnss.fallback.to.tle";
+  public static final String PLATFORM_GNSS_FALLBACK_TO_TLE_DEFAULT = "true";
+  /* UTC offset in milliseconds */
+  public static final String PLATFORM_GNSS_UTC_OFFSET_PROPERTY = "esa.mo.nmf.platform.gnss.utc.offset";
+  public static final String PLATFORM_GNSS_UTC_OFFSET_DEFAULT = "-18.000";
 }

--- a/core/mo-services-impl/nmf-platform-generic-impl/pom.xml
+++ b/core/mo-services-impl/nmf-platform-generic-impl/pom.xml
@@ -65,6 +65,11 @@
       <artifactId>ccsds-com</artifactId>
     </dependency>
     <dependency>
+      <groupId>int.esa.nmf.sdk</groupId>
+      <artifactId>orekit-resources</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/core/mo-services-impl/nmf-platform-generic-impl/src/main/java/esa/mo/platform/impl/provider/gen/GPSAdapterInterface.java
+++ b/core/mo-services-impl/nmf-platform-generic-impl/src/main/java/esa/mo/platform/impl/provider/gen/GPSAdapterInterface.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import org.ccsds.moims.mo.platform.gps.structures.Position;
 import org.ccsds.moims.mo.platform.gps.structures.SatelliteInfoList;
 import org.ccsds.moims.mo.platform.gps.structures.TwoLineElementSet;
+import org.orekit.propagation.analytical.tle.TLE;
 
 /**
  *
@@ -69,7 +70,8 @@ public interface GPSAdapterInterface
    * @return The current two line element set
    * @throws IOException if TLE can't be read
    */
-  TwoLineElementSet getTLE();
+  TLE getTLE();
+
 
   /**
    * Requests the BESTXYZ NMEA sentence

--- a/core/mo-services-impl/nmf-platform-generic-impl/src/main/java/esa/mo/platform/impl/provider/gen/GPSProviderServiceImpl.java
+++ b/core/mo-services-impl/nmf-platform-generic-impl/src/main/java/esa/mo/platform/impl/provider/gen/GPSProviderServiceImpl.java
@@ -26,15 +26,23 @@ import esa.mo.helpertools.connections.ConfigurationProviderSingleton;
 import esa.mo.helpertools.connections.ConnectionProvider;
 import esa.mo.helpertools.helpers.HelperMisc;
 import esa.mo.helpertools.helpers.HelperTime;
+import esa.mo.helpertools.misc.Const;
 import esa.mo.helpertools.misc.TaskScheduler;
+import esa.mo.nmf.sdk.OrekitResources;
 import esa.mo.platform.impl.util.HelperGPS;
 import esa.mo.platform.impl.util.PositionsCalculator;
 import esa.mo.reconfigurable.service.ConfigurationChangeListener;
 import esa.mo.reconfigurable.service.ReconfigurableService;
 import java.io.IOException;
-import java.text.NumberFormat;
-import java.util.HashMap;
-import java.util.Map;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalField;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -84,14 +92,22 @@ import org.ccsds.moims.mo.platform.gps.provider.GetSatellitesInfoInteraction;
 import org.ccsds.moims.mo.platform.gps.provider.GetTIMEASentenceInteraction;
 import org.ccsds.moims.mo.platform.gps.provider.GetTLEInteraction;
 import org.ccsds.moims.mo.platform.gps.provider.NearbyPositionPublisher;
-import org.ccsds.moims.mo.platform.gps.structures.NearbyPositionDefinition;
-import org.ccsds.moims.mo.platform.gps.structures.NearbyPositionDefinitionList;
-import org.ccsds.moims.mo.platform.gps.structures.Position;
-import org.ccsds.moims.mo.platform.gps.structures.PositionList;
-import org.ccsds.moims.mo.platform.gps.structures.SatelliteInfoList;
-import org.ccsds.moims.mo.platform.gps.structures.TwoLineElementSet;
+import org.ccsds.moims.mo.platform.gps.structures.*;
 import org.ccsds.moims.mo.platform.structures.VectorD3D;
 import org.ccsds.moims.mo.platform.structures.VectorF3D;
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
+import org.orekit.bodies.GeodeticPoint;
+import org.orekit.bodies.OneAxisEllipsoid;
+import org.orekit.data.DataProvidersManager;
+import org.orekit.frames.Frame;
+import org.orekit.frames.FramesFactory;
+import org.orekit.propagation.SpacecraftState;
+import org.orekit.propagation.analytical.tle.TLE;
+import org.orekit.propagation.analytical.tle.TLEPropagator;
+import org.orekit.time.AbsoluteDate;
+import org.orekit.time.TimeScalesFactory;
+import org.orekit.utils.Constants;
+import org.orekit.utils.IERSConventions;
 
 /**
  * GPS service Provider.
@@ -120,6 +136,15 @@ public class GPSProviderServiceImpl extends GPSInheritanceSkeleton
   private VectorF3D currentCartesianVelocityDeviation = null;
   private long timeOfCurrentPosition;
   private long timeOfCurrentPositionAndVelocity;
+
+  private Boolean isTLEFallbackEnabled =
+          Boolean.parseBoolean(System.getProperty(Const.PLATFORM_GNSS_FALLBACK_TO_TLE_PROPERTY,
+          Const.PLATFORM_GNSS_FALLBACK_TO_TLE_DEFAULT));
+
+  private static final int NANOSECONDS_IN_MILLISECOND = 1000000;
+  private Double utcOffset = Double.parseDouble(System.getProperty(Const.PLATFORM_GNSS_UTC_OFFSET_PROPERTY,
+          Const.PLATFORM_GNSS_UTC_OFFSET_DEFAULT));
+  private static boolean isOrekitDataInitialized = false;
 
   /**
    * creates the MAL objects, the publisher used to create updates and starts the publishing thread
@@ -294,13 +319,24 @@ public class GPSProviderServiceImpl extends GPSInheritanceSkeleton
   public void getPosition(GetPositionInteraction interaction)
       throws MALInteractionException, MALException
   {
+    boolean useTLEpropagation = false;
     if (!adapter.isUnitAvailable()) {
-      throw new MALInteractionException(
-          new MALStandardError(PlatformHelper.DEVICE_NOT_AVAILABLE_ERROR_NUMBER, null));
+      if(isTLEFallbackEnabled)
+      {
+        useTLEpropagation = true;
+      }
+      else
+      {
+        throw new MALInteractionException(
+                new MALStandardError(PlatformHelper.DEVICE_NOT_AVAILABLE_ERROR_NUMBER, null));
+      }
+    }
+    else if(!isPositionFixed()){
+        useTLEpropagation = true;
     }
 
     interaction.sendAcknowledgement();
-    Position position = adapter.getCurrentPosition();
+    Position position = useTLEpropagation ? getTLEPropagatedPosition() : adapter.getCurrentPosition();
     if (position == null) {
       throw new MALInteractionException(
           new MALStandardError(PlatformHelper.DEVICE_NOT_AVAILABLE_ERROR_NUMBER, null));
@@ -483,69 +519,110 @@ public class GPSProviderServiceImpl extends GPSInheritanceSkeleton
   public void getPositionAndVelocity(GetPositionAndVelocityInteraction interaction) throws
       MALInteractionException, MALException
   {
-    if (!adapter.isUnitAvailable()) { // Is the unit available?
-      throw new MALInteractionException(
-          new MALStandardError(PlatformHelper.DEVICE_NOT_AVAILABLE_ERROR_NUMBER, null));
-    }
-
-    interaction.sendAcknowledgement();
-    try {
-      String bestxyz = adapter.getBestXYZSentence();
-
-      String[] fields = HelperGPS.getDataFieldsFromBestXYZ(bestxyz);
-
-      final VectorD3D position = new VectorD3D(
-          Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.PX]),
-          Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.PY]),
-          Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.PZ])
-      );
-
-      final VectorF3D positionDeviation = new VectorF3D(
-          Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.PX_DEVIATION]),
-          Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.PY_DEVIATION]),
-          Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.PZ_DEVIATION])
-      );
-
-      final VectorD3D velocity = new VectorD3D(
-          Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.VX]),
-          Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.VY]),
-          Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.VZ])
-      );
-
-      final VectorF3D velocityDeviation = new VectorF3D(
-          Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.VX_DEVIATION]),
-          Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.VY_DEVIATION]),
-          Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.VZ_DEVIATION])
-      );
-
-      synchronized (MUTEX) { // Store the latest Position
-        currentCartesianPosition = position;
-        currentCartesianPositionDeviation = positionDeviation;
-        currentCartesianVelocity = velocity;
-        currentCartesianVelocityDeviation = velocityDeviation;
-        timeOfCurrentPositionAndVelocity = System.currentTimeMillis();
+    boolean useTLEpropagation = false;
+    if (!adapter.isUnitAvailable()) {
+      if(isTLEFallbackEnabled)
+      {
+        useTLEpropagation = true;
       }
-
-      interaction.sendResponse(position, positionDeviation, velocity, velocityDeviation);
-
-    } catch (IOException | NumberFormatException e) {
-      interaction
-          .sendError(new MALStandardError(PlatformHelper.DEVICE_NOT_AVAILABLE_ERROR_NUMBER, null));
-      e.printStackTrace();
+      else
+      {
+        throw new MALInteractionException(
+                new MALStandardError(PlatformHelper.DEVICE_NOT_AVAILABLE_ERROR_NUMBER, null));
+      }
     }
+    else if(!isPositionFixed()){
+      useTLEpropagation = true;
+    }
+
+      interaction.sendAcknowledgement();
+      try {
+        final VectorD3D position;
+        final VectorF3D positionDeviation;
+        final VectorD3D velocity;
+        final VectorF3D velocityDeviation;
+
+        if(useTLEpropagation)
+        {
+          Calendar targetDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+          SpacecraftState state = getSpacecraftState(targetDate);
+          Vector3D pos = state.getPVCoordinates().getPosition();
+          position = new VectorD3D(pos.getX(), pos.getY(), pos.getZ());
+
+          positionDeviation = new VectorF3D(0f, 0f, 0f);
+
+          Vector3D velocity3D = state.getPVCoordinates().getVelocity();
+          velocity = new VectorD3D(velocity3D.getX(), velocity3D.getY(), velocity3D.getZ());
+
+          velocityDeviation = new VectorF3D(0f, 0f, 0f);
+        }
+        else {
+          String bestxyz = adapter.getBestXYZSentence();
+
+          String[] fields = HelperGPS.getDataFieldsFromBestXYZ(bestxyz);
+
+          position = new VectorD3D(
+                  Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.PX]),
+                  Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.PY]),
+                  Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.PZ])
+          );
+
+          positionDeviation = new VectorF3D(
+                  Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.PX_DEVIATION]),
+                  Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.PY_DEVIATION]),
+                  Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.PZ_DEVIATION])
+          );
+
+          velocity = new VectorD3D(
+                  Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.VX]),
+                  Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.VY]),
+                  Double.parseDouble(fields[HelperGPS.BESTXYZ_FIELD.VZ])
+          );
+
+          velocityDeviation = new VectorF3D(
+                  Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.VX_DEVIATION]),
+                  Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.VY_DEVIATION]),
+                  Float.parseFloat(fields[HelperGPS.BESTXYZ_FIELD.VZ_DEVIATION])
+          );
+        }
+
+        synchronized (MUTEX) { // Store the latest Position
+          currentCartesianPosition = position;
+          currentCartesianPositionDeviation = positionDeviation;
+          currentCartesianVelocity = velocity;
+          currentCartesianVelocityDeviation = velocityDeviation;
+          timeOfCurrentPositionAndVelocity = System.currentTimeMillis();
+        }
+
+        interaction.sendResponse(position, positionDeviation, velocity, velocityDeviation);
+
+      } catch (IOException | NumberFormatException e) {
+        interaction
+                .sendError(new MALStandardError(PlatformHelper.DEVICE_NOT_AVAILABLE_ERROR_NUMBER, null));
+        e.printStackTrace();
+      }
 
   }
 
   @Override
   public void getTLE(GetTLEInteraction interaction) throws MALInteractionException, MALException
   {
-    if (!adapter.isUnitAvailable()) { // Is the unit available?
+    if (!adapter.isUnitAvailable() && isTLEFallbackEnabled == false) { // Is the unit available?
       throw new MALInteractionException(
           new MALStandardError(PlatformHelper.DEVICE_NOT_AVAILABLE_ERROR_NUMBER, null));
     }
     interaction.sendAcknowledgement();
-    TwoLineElementSet tle = adapter.getTLE();
-    interaction.sendResponse(tle);
+    TLE tle = adapter.getTLE();
+
+    interaction.sendResponse(new TwoLineElementSet(tle.getSatelliteNumber(), "" + tle.getClassification(),
+            tle.getLaunchYear(), tle.getLaunchNumber(), tle.getLaunchPiece(),
+            tle.getDate().getComponents(0).getDate().getYear(),
+            tle.getDate().getComponents(0).getDate().getDayOfYear(),
+            tle.getDate().getComponents(0).getTime().getSecondsInUTCDay(),
+            tle.getMeanMotionFirstDerivative(), tle.getMeanMotionSecondDerivative(),
+            tle.getBStar(), tle.getElementNumber(), tle.getI(), tle.getRaan(), tle.getE(),
+            tle.getPerigeeArgument(), tle.getMeanAnomaly(), tle.getMeanMotion(),
+            tle.getRevolutionNumberAtEpoch()));
   }
 
   public static final class PublishInteractionListener implements MALPublishInteractionListener
@@ -703,10 +780,18 @@ public class GPSProviderServiceImpl extends GPSInheritanceSkeleton
     {
       timer.scheduleTask(new Thread(() -> {
         if (active) {
-          if (!adapter.isUnitAvailable()) { // Is the unit available?
+          final Position pos;
+          if (adapter.isUnitAvailable()) { // Is the unit available?
+            pos = adapter.getCurrentPosition(); // Current Position
+          }
+          else if(!adapter.isUnitAvailable() && isTLEFallbackEnabled)
+          {
+            pos = getTLEPropagatedPosition(); // Use TLE propagated Position
+          }
+          else
+          {
             return;
           }
-          final Position pos = adapter.getCurrentPosition(); // Current Position
 
           synchronized (MUTEX) {
             currentPosition = pos;
@@ -757,8 +842,7 @@ public class GPSProviderServiceImpl extends GPSInheritanceSkeleton
     }
     interaction.sendAcknowledgement();
     try {
-      String resp = adapter.getBestXYZSentence();
-      interaction.sendResponse(resp);
+      interaction.sendResponse(adapter.getBestXYZSentence());
     } catch (IOException e) {
       interaction
           .sendError(new MALStandardError(PlatformHelper.DEVICE_NOT_AVAILABLE_ERROR_NUMBER, null));
@@ -776,13 +860,69 @@ public class GPSProviderServiceImpl extends GPSInheritanceSkeleton
     }
     interaction.sendAcknowledgement();
     try {
-      String resp = adapter.getTIMEASentence();
-      interaction.sendResponse(resp);
+      interaction.sendResponse(adapter.getTIMEASentence());
     } catch (IOException e) {
       interaction
           .sendError(new MALStandardError(PlatformHelper.DEVICE_NOT_AVAILABLE_ERROR_NUMBER, null));
       e.printStackTrace();
     }
+  }
+
+  /**
+   * Checks the fixQquality on the GNSS position.
+   * @return true if a fixed position has been established, false otherwise
+   */
+  private boolean isPositionFixed() {
+    boolean isFixed = false;
+    try {
+      if(adapter.getCurrentPosition().getExtraDetails().getFixQuality() > 0){
+        isFixed = true;
+      }
+    } catch (NullPointerException e)
+    {
+      LOGGER.warning("Could not receive a fixed position: " + e.getMessage());
+    }
+    return isFixed;
+  }
+
+  private Position getTLEPropagatedPosition()
+  {
+    Calendar targetDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    SpacecraftState state = getSpacecraftState(targetDate);
+
+
+    // Converting to geodetic lat/lon/alt
+    Frame ecf = FramesFactory.getITRF(IERSConventions.IERS_2010,true);
+    OneAxisEllipsoid earth = new OneAxisEllipsoid(Constants.WGS84_EARTH_EQUATORIAL_RADIUS, Constants.WGS84_EARTH_FLATTENING, ecf);
+    GeodeticPoint satLatLonAlt = earth.transform(state.getPVCoordinates().getPosition(), FramesFactory.getEME2000(),
+            state.getDate());
+
+    PositionExtraDetails extraDetails = new PositionExtraDetails(new Time(targetDate.getTimeInMillis()),
+            0, 0, 0.0f,0.0f, PositionSourceType.TLE);
+
+    return new Position((float) satLatLonAlt.getLatitude(), (float) satLatLonAlt.getLongitude(),
+            (float) satLatLonAlt.getAltitude(), extraDetails);
+  }
+
+  private SpacecraftState getSpacecraftState(Calendar targetDate) {
+
+    if(!isOrekitDataInitialized) {
+      //setup orekit if not yet initialized
+      DataProvidersManager manager = DataProvidersManager.getInstance();
+      if(manager.getProviders().isEmpty())
+      {
+        manager.addProvider(OrekitResources.getOrekitData());
+      }
+      isOrekitDataInitialized = true;
+    }
+
+    TLE tle = adapter.getTLE();
+    TLEPropagator propagator = TLEPropagator.selectExtrapolator(tle);
+
+    return propagator.propagate(new AbsoluteDate(targetDate.get(Calendar.YEAR),
+            targetDate.get(Calendar.MONTH) + 1,
+            targetDate.get(Calendar.DAY_OF_MONTH), targetDate.get(Calendar.HOUR_OF_DAY), targetDate.get(Calendar.MINUTE),
+            targetDate.get(Calendar.SECOND), TimeScalesFactory.getUTC()));
   }
 
 }

--- a/core/mo-services-impl/nmf-platform-generic-impl/src/main/java/esa/mo/platform/impl/util/HelperGPS.java
+++ b/core/mo-services-impl/nmf-platform-generic-impl/src/main/java/esa/mo/platform/impl/util/HelperGPS.java
@@ -26,10 +26,7 @@ import java.util.Calendar;
 import java.util.TimeZone;
 import org.ccsds.moims.mo.mal.structures.Time;
 import org.ccsds.moims.mo.mal.structures.UInteger;
-import org.ccsds.moims.mo.platform.gps.structures.Position;
-import org.ccsds.moims.mo.platform.gps.structures.PositionExtraDetails;
-import org.ccsds.moims.mo.platform.gps.structures.SatelliteInfo;
-import org.ccsds.moims.mo.platform.gps.structures.SatelliteInfoList;
+import org.ccsds.moims.mo.platform.gps.structures.*;
 
 /**
  * A Helper class with some conversions for GPS NMEA sentences
@@ -137,6 +134,7 @@ public class HelperGPS
           "W") ? -1 : 1));
 
       PositionExtraDetails posExtraDetails = new PositionExtraDetails();
+      posExtraDetails.setPositionSource(PositionSourceType.GNSS);
       if(items[GPGGA_GEN_COL.QUAL].length() != 0)
         posExtraDetails.setFixQuality(Integer.parseInt(items[GPGGA_GEN_COL.QUAL]));
       else

--- a/core/mo-services-xml/src/main/resources/xml/ServiceDefPLATFORM.xml
+++ b/core/mo-services-xml/src/main/resources/xml/ServiceDefPLATFORM.xml
@@ -899,7 +899,22 @@
                      name="undulation">
             <mal:type area="MAL" list="false" name="Float" />
           </mal:field>
+          <mal:field canBeNull="false"
+                     comment="Source of the position data (e.g. directly from GNSS or propagated via TLE)."
+                     name="positionSource">
+            <mal:type area="Platform" list="false"
+                      name="PositionSourceType" service="GPS"/>
+          </mal:field>
         </mal:composite>
+        <mal:enumeration
+                comment="GNSS position source."
+                name="PositionSourceType" shortFormPart="11">
+          <mal:item comment="GNSS"
+                    nvalue="1" value="GNSS" />
+          <mal:item
+                  comment="TLE propagation" nvalue="2"
+                  value="TLE" />
+        </mal:enumeration>
         <mal:composite
           comment="The NearbyPositionDefinition structure holds a definition of a certain Position."
           name="NearbyPositionDefinition" shortFormPart="26">

--- a/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/orekit/OrekitCore.java
+++ b/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/orekit/OrekitCore.java
@@ -214,6 +214,7 @@ public class OrekitCore
   private AttitudeStateProvider attitudeState;
   boolean isInitialized;
   private int tleNumber = 0;
+  private long lastTLEPropagatorWarningTime = 0;
   private Logger logger;
 
   // Magnetic field
@@ -1339,16 +1340,19 @@ public class OrekitCore
 
     if (this.runningPropagator instanceof TLEPropagator) {
       return ((TLEPropagator) this.runningPropagator).getTLE();
-    } else { // in case we are using the keplerian propagator, the TLE can not be reconstructed completle!
-      this.logger.log(Level.WARNING,
-          "Using getTLE() with any other than the TLEPropagator results in incomplete and inaccurate TLE Messages!"
-          + "\n"
-          + "Catalog Number, launch year, launch number, ephemeris type, mean motion d1 and d2, number of revolutions and BStart will be set to 0"
-          + "\n"
-          + "launch Piece will be set to \"N\", classification will be set to 'U'"
-          + "\n"
-          + "Element number will start at 0 and count up on every call of getTLE()");
-
+    } else {
+      // in case we are using the keplerian propagator, the TLE can not be reconstructed completle!
+      if(System.currentTimeMillis() - lastTLEPropagatorWarningTime > 60000 ) { //Reduce the logging frequency
+        this.logger.log(Level.WARNING,
+                "Using getTLE() with any other than the TLEPropagator results in incomplete and inaccurate TLE Messages!"
+                        + "\n"
+                        + "Catalog Number, launch year, launch number, ephemeris type, mean motion d1 and d2, number of revolutions and BStart will be set to 0"
+                        + "\n"
+                        + "launch Piece will be set to \"N\", classification will be set to 'U'"
+                        + "\n"
+                        + "Element number will start at 0 and count up on every call of getTLE()");
+        lastTLEPropagatorWarningTime = System.currentTimeMillis();
+      }
       KeplerianOrbit orbit = (KeplerianOrbit) OrbitType.KEPLERIAN.convertType(this.getOrbit());
 
       int SatelliteNumber = 0;

--- a/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/util/SimulatorData.java
+++ b/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/util/SimulatorData.java
@@ -166,23 +166,23 @@ public class SimulatorData implements Serializable {
         return currentTimeLong;
     }
     public String getUTCCurrentTime() {
-        DateFormat df = new SimpleDateFormat("hhmmss.SS");
+        DateFormat df = new SimpleDateFormat("HHmmss.SS");
         return df.format(currentTime);
     }
     public String getUTCCurrentTime2() {
-        DateFormat df = new SimpleDateFormat("hhmm");
+        DateFormat df = new SimpleDateFormat("HHmm");
         return df.format(currentTime);
     }
     public String getUTCCurrentHour() {
-        DateFormat df = new SimpleDateFormat("hh");
+        DateFormat df = new SimpleDateFormat("H");
         return df.format(currentTime);
     }
     public String getUTCCurrentMinute() {
-        DateFormat df = new SimpleDateFormat("mm");
+        DateFormat df = new SimpleDateFormat("m");
         return df.format(currentTime);
     }
     public String getUTCCurrentSecond() {
-        DateFormat df = new SimpleDateFormat("ss");
+        DateFormat df = new SimpleDateFormat("s");
         return df.format(currentTime);
     }
     public String getUTCCurrentMillis() {

--- a/mission/simulator/platform-services-impl/src/main/java/esa/mo/platform/impl/provider/softsim/GPSSoftSimAdapter.java
+++ b/mission/simulator/platform-services-impl/src/main/java/esa/mo/platform/impl/provider/softsim/GPSSoftSimAdapter.java
@@ -88,19 +88,11 @@ public class GPSSoftSimAdapter extends GPSNMEAonlyAdapter
   }
 
   @Override
-  public TwoLineElementSet getTLE()
+  public TLE getTLE()
   {
     TLE tle = this.instrumentsSimulator.getSimulatorNode().getTLE();
 
-    return new TwoLineElementSet(tle.getSatelliteNumber(), "" + tle.getClassification(),
-        tle.getLaunchYear(), tle.getLaunchNumber(), tle.getLaunchPiece(),
-        tle.getDate().getComponents(0).getDate().getYear(),
-        tle.getDate().getComponents(0).getDate().getDayOfYear(),
-        tle.getDate().getComponents(0).getTime().getSecondsInUTCDay(),
-        tle.getMeanMotionFirstDerivative(), tle.getMeanMotionSecondDerivative(),
-        tle.getBStar(), tle.getElementNumber(), tle.getI(), tle.getRaan(), tle.getE(),
-        tle.getPerigeeArgument(), tle.getMeanAnomaly(), tle.getMeanMotion(),
-        tle.getRevolutionNumberAtEpoch());
+    return tle;
   }
 
 }

--- a/mission/simulator/platform-services-impl/src/test/java/esa/nmf/test/GPSSoftSimAdapterTest.java
+++ b/mission/simulator/platform-services-impl/src/test/java/esa/nmf/test/GPSSoftSimAdapterTest.java
@@ -10,6 +10,11 @@ public class GPSSoftSimAdapterTest {
 
     private static opssat.simulator.main.ESASimulator eSASimulator = new ESASimulator();
 
+    private final static String CLOCK_MODEL_STATUS = "(VALID|CONVERGING|ITERATING|INVALID)";
+    private final static String UTC_STATUS = "(VALID|INVALID|WARNING)";
+    private final static String GPS_REF_TIME_STATUS = "(UNKNOWN|APPROXIMATE|COARSEADJUSTING|COARSE|COARSESTEERING" +
+            "|FREEWHEELING|FINEADJUSTING|FINE|FINEBACKUPSTEERING|FINESTEERING|SATTIME)";
+
     @Test
     public void testTIMEAFormat() throws IOException {
         esa.mo.platform.impl.provider.softsim.PowerControlSoftSimAdapter pcAdapter =
@@ -18,9 +23,11 @@ public class GPSSoftSimAdapterTest {
                 new esa.mo.platform.impl.provider.softsim.GPSSoftSimAdapter(eSASimulator, pcAdapter);
         //Expecting something in lines of:
         //#TIMEA,COM1,0,35.0,FINESTEERING,1337,410010.000,00000000,9924,1984;VALID,0,0,0,2005,8,25,17,53,17000,VALID*e2fc088c
-        String expectedRegex = "#TIMEA,COM1,0,35\\.0,FINESTEERING,\\d{4},\\d{6}\\.\\d{1,3},[0|1]{8},[\\d|\\D]{4}," +
-                "\\d{4};VALID,0,0,-?\\d{1,2}\\.\\d{11},\\d{4},\\d{1,2},\\d{1,2},\\d{1,2},\\d{1,2},\\d{5}," +
-                "VALID\\*[\\D|\\d]{1,8}";
+        String expectedRegex = "#TIMEA,\\w{1,8}_?\\d{1,2},0,\\d{1,2}\\.\\d{1,2}," + GPS_REF_TIME_STATUS +
+                ",\\d{4},\\d{1,6}\\.\\d{3},[0|1]{8},[\\d|\\w]{4},\\d{1,5};" + CLOCK_MODEL_STATUS +
+                ",(0|\\d{1,2}\\.\\d{1,13}(e-)?(\\d{1,2})?),(0|\\d{1,2}\\.\\d{1,13}(e-)?(\\d{1,2})?)," +
+                "-?\\d{1,2}\\.\\d{11},\\d{4},\\d{1,2},\\d{1,2},\\d{1,2}," +
+                "\\d{1,2},\\d{1,5},"+ UTC_STATUS + "\\*[\\w|\\d]{1,8}";
         String timea = gPSSoftSimAdapter.getTIMEASentence();
         Assert.assertTrue("Actual was: " +timea, timea.matches(expectedRegex));
     }
@@ -33,8 +40,8 @@ public class GPSSoftSimAdapterTest {
                 new esa.mo.platform.impl.provider.softsim.GPSSoftSimAdapter(eSASimulator, pcAdapter);
         //Expecting the BESTXYZ header to be in the lines of:
         //#BESTXYZA,COM1,0,35.0,FINESTEERING,2177,306117.000,00100000,97b7,2310...
-        String expectedRegex = "^#BESTXYZA,COM1,0,35\\.0,FINESTEERING,\\d{4},\\d{6}\\.\\d{1,3},[0|1]{8}," +
-                "[\\d|\\D]{4},\\d{4}.+";
+        String expectedRegex = "^#BESTXYZA,\\w{1,8}_?\\d{1,2},0,\\d{1,2}\\.\\d{1,2}," + GPS_REF_TIME_STATUS +
+                ",\\d{4},\\d{1,6}\\.\\d{3},[0-9|A-F|a-f]{8},[\\d|\\w]{4},\\d{1,5}.+";
         String timea = gPSSoftSimAdapter.getBestXYZSentence();
         Assert.assertTrue("Actual was: " +timea, timea.matches(expectedRegex));
     }

--- a/sdk/sdk-package/src/main/resources/space-supervisor-root/provider.properties
+++ b/sdk/sdk-package/src/main/resources/space-supervisor-root/provider.properties
@@ -26,7 +26,11 @@ esa.mo.nanosatmoframework.appslauncher.stdlimit=2048
 # Cleanup space archive from synchronised objects
 esa.mo.nanosatmoframework.archivesync.purgearchive=true
 
+# Whether to use TLE propagation when GNSS is powered off
+esa.mo.nmf.platform.gnss.fallback.to.tle=true
+
 # configuration for gps polling behaviour
 helpertools.configurations.pollgps=true
+
 # pollrate in ms
 helpertools.configurations.gpspollrate=5000


### PR DESCRIPTION
Option to use TLE propagation instead when GPS device
is unavailable. Also when GPS receiver is powered on,
but has no valid lock.