### PR TITLE
Bug #1158 [sim] Wrong GNSS log format

### DIFF
--- a/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/util/SimulatorData.java
+++ b/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/util/SimulatorData.java
@@ -166,23 +166,23 @@ public class SimulatorData implements Serializable {
         return currentTimeLong;
     }
     public String getUTCCurrentTime() {
-        DateFormat df = new SimpleDateFormat("hhmmss.SS");
+        DateFormat df = new SimpleDateFormat("HHmmss.SS");
         return df.format(currentTime);
     }
     public String getUTCCurrentTime2() {
-        DateFormat df = new SimpleDateFormat("hhmm");
+        DateFormat df = new SimpleDateFormat("HHmm");
         return df.format(currentTime);
     }
     public String getUTCCurrentHour() {
-        DateFormat df = new SimpleDateFormat("hh");
+        DateFormat df = new SimpleDateFormat("H");
         return df.format(currentTime);
     }
     public String getUTCCurrentMinute() {
-        DateFormat df = new SimpleDateFormat("mm");
+        DateFormat df = new SimpleDateFormat("m");
         return df.format(currentTime);
     }
     public String getUTCCurrentSecond() {
-        DateFormat df = new SimpleDateFormat("ss");
+        DateFormat df = new SimpleDateFormat("s");
         return df.format(currentTime);
     }
     public String getUTCCurrentMillis() {

--- a/mission/simulator/platform-services-impl/src/test/java/esa/nmf/test/GPSSoftSimAdapterTest.java
+++ b/mission/simulator/platform-services-impl/src/test/java/esa/nmf/test/GPSSoftSimAdapterTest.java
@@ -10,6 +10,11 @@ public class GPSSoftSimAdapterTest {
 
     private static opssat.simulator.main.ESASimulator eSASimulator = new ESASimulator();
 
+    private final static String CLOCK_MODEL_STATUS = "(VALID|CONVERGING|ITERATING|INVALID)";
+    private final static String UTC_STATUS = "(VALID|INVALID|WARNING)";
+    private final static String GPS_REF_TIME_STATUS = "(UNKNOWN|APPROXIMATE|COARSEADJUSTING|COARSE|COARSESTEERING" +
+            "|FREEWHEELING|FINEADJUSTING|FINE|FINEBACKUPSTEERING|FINESTEERING|SATTIME)";
+
     @Test
     public void testTIMEAFormat() throws IOException {
         esa.mo.platform.impl.provider.softsim.PowerControlSoftSimAdapter pcAdapter =
@@ -18,9 +23,11 @@ public class GPSSoftSimAdapterTest {
                 new esa.mo.platform.impl.provider.softsim.GPSSoftSimAdapter(eSASimulator, pcAdapter);
         //Expecting something in lines of:
         //#TIMEA,COM1,0,35.0,FINESTEERING,1337,410010.000,00000000,9924,1984;VALID,0,0,0,2005,8,25,17,53,17000,VALID*e2fc088c
-        String expectedRegex = "#TIMEA,COM1,0,35\\.0,FINESTEERING,\\d{4},\\d{6}\\.\\d{1,3},[0|1]{8},[\\d|\\D]{4}," +
-                "\\d{4};VALID,0,0,-?\\d{1,2}\\.\\d{11},\\d{4},\\d{1,2},\\d{1,2},\\d{1,2},\\d{1,2},\\d{5}," +
-                "VALID\\*[\\D|\\d]{1,8}";
+        String expectedRegex = "#TIMEA,\\w{1,8}_?\\d{1,2},0,\\d{1,2}\\.\\d{1,2}," + GPS_REF_TIME_STATUS +
+                ",\\d{4},\\d{1,6}\\.\\d{3},[0|1]{8},[\\d|\\w]{4},\\d{1,5};" + CLOCK_MODEL_STATUS +
+                ",(0|\\d{1,2}\\.\\d{1,13}(e-)?(\\d{1,2})?),(0|\\d{1,2}\\.\\d{1,13}(e-)?(\\d{1,2})?)," +
+                "-?\\d{1,2}\\.\\d{11},\\d{4},\\d{1,2},\\d{1,2},\\d{1,2}," +
+                "\\d{1,2},\\d{1,5},"+ UTC_STATUS + "\\*[\\w|\\d]{1,8}";
         String timea = gPSSoftSimAdapter.getTIMEASentence();
         Assert.assertTrue("Actual was: " +timea, timea.matches(expectedRegex));
     }
@@ -33,8 +40,8 @@ public class GPSSoftSimAdapterTest {
                 new esa.mo.platform.impl.provider.softsim.GPSSoftSimAdapter(eSASimulator, pcAdapter);
         //Expecting the BESTXYZ header to be in the lines of:
         //#BESTXYZA,COM1,0,35.0,FINESTEERING,2177,306117.000,00100000,97b7,2310...
-        String expectedRegex = "^#BESTXYZA,COM1,0,35\\.0,FINESTEERING,\\d{4},\\d{6}\\.\\d{1,3},[0|1]{8}," +
-                "[\\d|\\D]{4},\\d{4}.+";
+        String expectedRegex = "^#BESTXYZA,\\w{1,8}_?\\d{1,2},0,\\d{1,2}\\.\\d{1,2}," + GPS_REF_TIME_STATUS +
+                ",\\d{4},\\d{1,6}\\.\\d{3},[0-9|A-F|a-f]{8},[\\d|\\w]{4},\\d{1,5}.+";
         String timea = gPSSoftSimAdapter.getBestXYZSentence();
         Assert.assertTrue("Actual was: " +timea, timea.matches(expectedRegex));
     }


### PR DESCRIPTION
Improve the unit tests - make them more universal, following the OEM manual.
Fix the time formats in simulator - 12H format was used instead of 24H. 