### PR TITLE
Issue #1189 COM Archive Tool - support parameters from multiple domains

### DIFF
--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/ArchiveBrowserHelper.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/ArchiveBrowserHelper.java
@@ -269,6 +269,7 @@ public class ArchiveBrowserHelper {
 
         String login = System.console().readLine("Login: ");
         char[] password = System.console().readPassword("Password: ");
+        System.out.println();
 
         LongList rolesIds = consumer.getCommonServices().getLoginService().getLoginStub().listRoles(new Identifier(login), String.valueOf(password));
 
@@ -290,7 +291,7 @@ public class ArchiveBrowserHelper {
 
         Long roleId = null;
         if(!adapter.getRolesIds().isEmpty()) {
-          System.out.println("Available roles: ");
+          System.out.println("\nAvailable roles: ");
           for(int i = 0; i < adapter.getRolesIds().size(); ++i) {
             System.out.println((i + 1) + " - " + adapter.getRolesNames().get(i));
           }

--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/adapters/ArchiveToParametersAdapter.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/adapters/ArchiveToParametersAdapter.java
@@ -34,7 +34,6 @@ import org.ccsds.moims.mo.mc.parameter.structures.ParameterValue;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * Archive adapter that retrieves available parameter names and their values.
@@ -208,20 +207,7 @@ public class ArchiveToParametersAdapter extends ArchiveAdapter implements QueryS
         return parameterValues;
     }
 
-    public Identifier getParameterIdentifierByDefinitionId(Long definitionId)
-    {
-        return identitiesMap.get(definitionsMap.get(definitionId));
-    }
-
-    public Long getParameterDefinitionIdByIdentifer(Identifier identifier)
-    {
-        for(Map.Entry entry: identitiesMap.entrySet())
-        {
-            if(Objects.equals(entry.getValue(), identifier))
-            {
-                return (Long) entry.getKey();
-            }
-        }
-        return null;
+    public Map<IdentifierList, Map<Long, Identifier>> getIdentitiesMap() {
+        return identitiesMap;
     }
 }

--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/logs/LogsCommandsImplementations.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/logs/LogsCommandsImplementations.java
@@ -129,7 +129,7 @@ public class LogsCommandsImplementations {
                                AppsLauncherHelper.APPSLAUNCHER_SERVICE_NUMBER,
                                SoftwareManagementHelper.SOFTWAREMANAGEMENT_AREA_VERSION, new UShort(0));
 
-        LocalOrRemoteConsumer consumers = createConsumer(providerURI, databaseFile);
+        LocalOrRemoteConsumer consumers = createConsumer(providerURI, databaseFile, appName);
         ArchiveConsumerServiceImpl localConsumer = consumers.getLocalConsumer();
         NMFConsumer remoteConsumer = consumers.getRemoteConsumer();
 

--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/parameters/ParametersCommandsDefinitions.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/parameters/ParametersCommandsDefinitions.java
@@ -51,7 +51,7 @@ public class ParametersCommandsDefinitions {
         @ArgGroup(multiplicity = "1")
         ArchiveBrowserHelper.LocalOrRemote localOrRemote;
 
-        @Parameters(arity = "1", paramLabel = "<appName>", index = "0",
+        @Option(names = {"-p", "--provider"}, paramLabel = "<appName>",
                 description = "Name of the NMF app we want the parameters for")
         String appName;
 
@@ -82,11 +82,11 @@ public class ParametersCommandsDefinitions {
                     description = "Target file for the parameters samples")
         String parametersFile;
 
-        @Parameters(arity = "1", paramLabel = "<appName>", index = "1",
-                    description = "Name of the NMF app we want the parameters for")
+        @Option(names = {"-p", "--provider"}, paramLabel = "<appName>",
+                description = "Name of the NMF app we want the parameters for")
         String appName;
 
-        @Parameters(arity = "0..*", paramLabel = "<parameterNames>", index = "2",
+        @Parameters(arity = "0..*", paramLabel = "<parameterNames>", index = "1",
                     description = "Names of the parameters to retrieve\n"
                                   + " - examples: param1 or param1 param2")
         List<String> parameterNames;

--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/parameters/ParametersCommandsDefinitions.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/parameters/ParametersCommandsDefinitions.java
@@ -51,6 +51,10 @@ public class ParametersCommandsDefinitions {
         @ArgGroup(multiplicity = "1")
         ArchiveBrowserHelper.LocalOrRemote localOrRemote;
 
+        @Parameters(arity = "1", paramLabel = "<appName>", index = "0",
+                description = "Name of the NMF app we want the parameters for")
+        String appName;
+
         @Option(names = {"-d", "--domain"}, paramLabel = "<domainId>",
                 description = "Restricts the dump to objects in a specific domain\n"
                         + "  - format: key1.key2.[...].keyN.\n"
@@ -61,7 +65,7 @@ public class ParametersCommandsDefinitions {
         @Override
         public void run() {
             ParametersCommandsImplementations.listParameters(localOrRemote.databaseFile, localOrRemote.providerURI,
-                    domain);
+                    domain, appName);
         }
     }
 
@@ -78,10 +82,20 @@ public class ParametersCommandsDefinitions {
                     description = "Target file for the parameters samples")
         String parametersFile;
 
-        @Parameters(arity = "0..*", paramLabel = "<parameterNames>", index = "1",
+        @Parameters(arity = "1", paramLabel = "<appName>", index = "1",
+                    description = "Name of the NMF app we want the parameters for")
+        String appName;
+
+        @Parameters(arity = "0..*", paramLabel = "<parameterNames>", index = "2",
                     description = "Names of the parameters to retrieve\n"
                                   + " - examples: param1 or param1 param2")
         List<String> parameterNames;
+
+        @Option(names = {"-d", "--domain"}, paramLabel = "<domainId>",
+                description = "Restricts the dump to parameters in a specific domain\n"
+                              + "  - format: key1.key2.[...].keyN.\n"
+                              + "  - example: esa.NMF_SDK.nanosat-mo-supervisor")
+        String domain;
 
         @Option(names = {"-s", "--start"}, paramLabel = "<startTime>",
                 description = "Restricts the dump to parameters generated after the given time\n"
@@ -96,12 +110,6 @@ public class ParametersCommandsDefinitions {
                               + "  - example: \"2021-03-05 12:05:45.271\"")
         String endTime;
 
-        @Option(names = {"-d", "--domain"}, paramLabel = "<domainId>",
-                description = "Restricts the dump to objects in a specific domain\n"
-                        + "  - format: key1.key2.[...].keyN.\n"
-                        + "  - example: esa.NMF_SDK.nanosat-mo-supervisor")
-        String domain;
-
         @Option(names = {"-j", "--json"}, paramLabel = "<json>",
                 description = "If specified output will be in JSON format")
         boolean json;
@@ -109,8 +117,8 @@ public class ParametersCommandsDefinitions {
         @Override
         public void run() {
             ParametersCommandsImplementations.getParameters(localOrRemote.databaseFile, localOrRemote.providerURI,
-                                                            startTime, endTime, domain, parametersFile, parameterNames,
-                                                            json);
+                                                            domain, startTime, endTime, parametersFile, appName,
+                                                            parameterNames, json);
         }
     }
 

--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/parameters/ParametersCommandsImplementations.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/parameters/ParametersCommandsImplementations.java
@@ -78,11 +78,6 @@ public class ParametersCommandsImplementations {
 
         IdentifierList domain = domainId == null ? null : HelperMisc.domainId2domain(domainId);
 
-        if(remoteConsumer != null && domainId == null &&
-           providerURI.contains("LWMCS_Core") && !appName.equals("App: LWMCS_Core")) {
-            domain = remoteConsumer.getConnectionConsumer().getServicesDetails().get(DirectoryHelper.DIRECTORY_SERVICE_NAME).getDomain();
-        }
-
         ArchiveQueryList archiveQueryList = new ArchiveQueryList();
         ArchiveQuery archiveQuery = new ArchiveQuery(domain, null, null,
                                                      0L, null, null,
@@ -137,12 +132,6 @@ public class ParametersCommandsImplementations {
         FineTime startTimeF = startTime == null ? null : HelperTime.readableString2FineTime(startTime);
         FineTime endTimeF = endTime == null ? null : HelperTime.readableString2FineTime(endTime);
         IdentifierList domain = domainId == null ? null : HelperMisc.domainId2domain(domainId);
-
-        if(remoteConsumer != null && domainId == null &&
-           providerURI.contains("LWMCS_Core") && !appName.equals("App: LWMCS_Core")) {
-            domain = remoteConsumer.getConnectionConsumer().getServicesDetails().get(DirectoryHelper.DIRECTORY_SERVICE_NAME).getDomain();
-            System.out.println("\nSetting domain to: " + domain);
-        }
 
         ArchiveQuery archiveQuery = new ArchiveQuery(domain, null, null, 0L, null,
                                                      startTimeF, endTimeF, null, null);


### PR DESCRIPTION
It is now possible to filter parameters based on the domain. There are some changes to how the commands should be called. Both `parameter list` and `parameter get` commands now require provider name as a parameter. Some examples:

Get all parameters from the LWMCS archive:
`parameter get -r maltcp://127.0.0.1:61617/LWMCS_Core-Directory parameters.log "App: LWMCS_Core"`
Providing "App: LWMCS_Core" as a provider name causes the tool to download parameters from the LWMCS archive containing all synchronized parameters. It is also possible to get parameters for a specific provider by providing a domain filter:
`parameter get -r maltcp://127.0.0.1:61617/LWMCS_Core-Directory -d some.provider.domain parameters.log "App: LWMCS_Core"`

There's also an option to get latest parameters directly from a provider using LWMCS as a proxy:
 `parameter get -r maltcp://127.0.0.1:61617/LWMCS_Core-Directory parameters.log "App: backend_test_service"`
Setting provider name other than "App: LWMCS_Core" will cause LWMCS to get the sychronized parameters from the local archive (if there are any) but also proxy the request directly to the space backend to get the latest values. Of course you can also provide a space backend directory uri to bypass LWMCS completely.

When quering a local archive the provider name parameter is ignored but still required. The only way to filter the parameters is by providing a domain. For example:
`parameter get -l comArchive.db -d some.provider.domain parameters.log "ignored provider name"`

When using the `parameter list` command same rules apply as to the `parameter get` command. The provider name is required when connecting to a remote archive. When connecting to a local archive the parameter is required but ignored.