### PR TITLE
Issue #1191 [package-manager] Fix path traversal write by Zip Slip vulnerability

### DIFF
--- a/core/nmf-package-lib/src/main/java/esa/mo/nmf/nmfpackage/NMFPackageManager.java
+++ b/core/nmf-package-lib/src/main/java/esa/mo/nmf/nmfpackage/NMFPackageManager.java
@@ -481,8 +481,9 @@ public class NMFPackageManager {
     }
 
     private static String generateFilePathForSystem(final String path) {
-        String out = path.replace('/', File.separatorChar);
-        return out.replace('\\', File.separatorChar);
+        String out = path.replace("..", "\u0000");
+        String out1 = out.replace('/', File.separatorChar);
+        return out1.replace('\\', File.separatorChar);
     }
 
     private static void copyFiles(final NMFPackageDescriptor descriptor,


### PR DESCRIPTION
Issue #1191 [package-manager] Fix path traversal write by Zip Slip vulnerability

https://gitlab.com/esa/NMF/nmf-issues/-/issues/1191

Fix the method generateFilePathForSystem() so the generated
path cannot go above the experimenter's folder