### PR TITLE
[GPS Provider Service] Change propagated TLE latitude units to degrees

### DIFF
--- a/core/mo-services-impl/nmf-platform-generic-impl/src/main/java/esa/mo/platform/impl/provider/gen/GPSProviderServiceImpl.java
+++ b/core/mo-services-impl/nmf-platform-generic-impl/src/main/java/esa/mo/platform/impl/provider/gen/GPSProviderServiceImpl.java
@@ -903,7 +903,7 @@ public class GPSProviderServiceImpl extends GPSInheritanceSkeleton
     PositionExtraDetails extraDetails = new PositionExtraDetails(new Time(targetDate.getTimeInMillis()),
             0, 0, 0.0f,0.0f, PositionSourceType.TLE);
 
-    return new Position((float) satLatLonAlt.getLatitude(), (float) FastMath.toDegrees(satLatLonAlt.getLongitude()),
+    return new Position((float) FastMath.toDegrees(satLatLonAlt.getLatitude()), (float) FastMath.toDegrees(satLatLonAlt.getLongitude()),
             (float) FastMath.toDegrees(satLatLonAlt.getAltitude()), extraDetails);
   }
 


### PR DESCRIPTION
[GPS Provider Service] Change propagated TLE latitude units to degrees

Fix method getTLEPropagatedPosition() so that it
returns Position latitude in degrees like it does with 
longitude and altitude