### PR TITLE
[Camera Simulator] Make accepted file extentions case insensitive

### DIFF
--- a/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/threading/SimulatorNode.java
+++ b/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/threading/SimulatorNode.java
@@ -621,8 +621,8 @@ public class SimulatorNode extends TaskNode
       try {
         Stream<Path> walker = Files.walk(Paths.get(path));
         List<String> files = walker
-            .map(p -> p.getFileName().toString()).filter(s -> s.endsWith(".png")
-            || s.endsWith(".jpg") || s.endsWith("bmp") || s.endsWith(".raw"))
+            .map(p -> p.getFileName().toString()).filter(s -> s.toLowerCase().endsWith(".png")
+            || s.toLowerCase().endsWith(".jpg") || s.toLowerCase().endsWith("bmp") || s.toLowerCase().endsWith(".raw"))
             .collect(Collectors.toList());
         walker.close();
         Random r = new Random();


### PR DESCRIPTION
Change reloadImageBuffer() method
to be case insensitive to file extentions
Solved by: Pablo Ghiglino
email: pablo.ghiglino@klepsydra.com