### PR TITLE
Issue #1192 [OBSW Parameter Manager] Allow Parameter::setValue calls

### DIFF
--- a/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/MCSupervisorBasicAdapter.java
+++ b/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/MCSupervisorBasicAdapter.java
@@ -21,6 +21,9 @@
 package esa.mo.nmf.nanosatmosupervisor;
 
 import esa.mo.helpertools.connections.ConnectionConsumer;
+import esa.mo.helpertools.helpers.HelperAttributes;
+import esa.mo.helpertools.helpers.HelperTime;
+
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -35,7 +38,10 @@ import org.ccsds.moims.mo.mal.MALStandardError;
 import org.ccsds.moims.mo.mal.provider.MALInteraction;
 import org.ccsds.moims.mo.mal.structures.UInteger;
 import org.ccsds.moims.mo.mal.transport.MALMessageHeader;
+import org.ccsds.moims.mo.mc.parameter.structures.ParameterRawValue;
 import org.ccsds.moims.mo.platform.gps.consumer.GPSAdapter;
+import org.w3c.dom.Attr;
+
 import esa.mo.nmf.MCRegistration;
 import esa.mo.nmf.MonitorAndControlNMFAdapter;
 import esa.mo.nmf.NMFException;

--- a/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/parameter/DummyValuesProvider.java
+++ b/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/parameter/DummyValuesProvider.java
@@ -21,6 +21,8 @@
 package esa.mo.nmf.nanosatmosupervisor.parameter;
 
 import java.util.HashMap;
+import java.util.Map;
+
 import org.ccsds.moims.mo.mal.structures.Attribute;
 import org.ccsds.moims.mo.mal.structures.Identifier;
 import esa.mo.helpertools.helpers.HelperAttributes;
@@ -34,12 +36,18 @@ import esa.mo.helpertools.helpers.HelperAttributes;
 public class DummyValuesProvider extends OBSWParameterValuesProvider {
 
   /**
+   * Dummy Map of OBSW parameter value by parameter name acting as our cache storage.
+   */
+  private final Map<Identifier, Attribute> parameterStorage;
+
+  /**
    * Creates a new instance of DummyValuesProvider.
    * 
    * @param parameterMap The map of OBSW parameters for which we have to provide values for
    */
   public DummyValuesProvider(HashMap<Identifier, OBSWParameter> parameterMap) {
     super(parameterMap);
+    parameterStorage = new HashMap<>();
   }
 
   /** {@inheritDoc} */
@@ -48,7 +56,24 @@ public class DummyValuesProvider extends OBSWParameterValuesProvider {
     if (!parameterMap.containsKey(identifier)) {
       return null;
     }
-    OBSWParameter param = parameterMap.get(identifier);
-    return HelperAttributes.attributeName2Attribute(param.getType());
+    if (parameterStorage.containsKey(identifier)){
+      return parameterStorage.get(identifier);
+    }else{
+      OBSWParameter param = parameterMap.get(identifier);
+      return HelperAttributes.attributeName2Attribute(param.getType());
+    }
+  }
+
+  @Override
+  public Boolean setValue(Attribute rawValue, Identifier identifier){
+    if (!parameterMap.containsKey(identifier)) {
+      return false;
+    }
+    if (!parameterStorage.containsKey(identifier)){
+      parameterStorage.put(identifier, rawValue);
+    }else {
+      parameterStorage.replace(identifier, rawValue);
+    }
+    return true;
   }
 }

--- a/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/parameter/OBSWParameterManager.java
+++ b/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/parameter/OBSWParameterManager.java
@@ -35,6 +35,8 @@ import org.ccsds.moims.mo.mal.structures.IdentifierList;
 import org.ccsds.moims.mo.mal.structures.LongList;
 import org.ccsds.moims.mo.mc.parameter.structures.ParameterDefinitionDetails;
 import org.ccsds.moims.mo.mc.parameter.structures.ParameterDefinitionDetailsList;
+import org.ccsds.moims.mo.mc.parameter.structures.ParameterRawValue;
+
 import esa.mo.helpertools.helpers.HelperAttributes;
 import esa.mo.nmf.MCRegistration;
 
@@ -137,6 +139,19 @@ public class OBSWParameterManager {
     return getValue(obswParamIdentifier);
   }
 
+
+  /**
+   * Sets a new value to a given OBSW parameter.
+   * 
+   * @param newRawValue the new value
+   * @return true if parameter is set, false otherwise.
+   */
+  public Boolean setValue(ParameterRawValue newRawValue){
+    Identifier obswParamIdentifier = 
+      new Identifier(proxyIdsToOBSWParams.get(newRawValue.getParamInstId()).getName());
+    return setValue(newRawValue.getRawValue(), obswParamIdentifier);
+  }
+
   /**
    * @param parameterID The parameter ID to test
    * @return true if the ID corresponds to one of the parameter proxies registered by this class
@@ -153,5 +168,17 @@ public class OBSWParameterManager {
    */
   private Attribute getValue(Identifier identifier) {
     return valuesProvider.getValue(identifier);
+  }
+
+
+  /**
+   * Sets a new value for the given OBSW parameter name.
+   * 
+   * @param rawValue The new value of the parameter
+   * @param identifier Name of the parameter
+   * @return True if parameter is set, false otherwise.
+   */
+  private Boolean setValue(Attribute rawValue, Identifier identifier){
+    return valuesProvider.setValue(rawValue, identifier);
   }
 }

--- a/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/parameter/OBSWParameterValuesProvider.java
+++ b/core/nmf-composites/nanosat-mo-supervisor/src/main/java/esa/mo/nmf/nanosatmosupervisor/parameter/OBSWParameterValuesProvider.java
@@ -65,4 +65,14 @@ public abstract class OBSWParameterValuesProvider {
    * @return The value or null if the parameter name is unknown or a problem happened while fetching the value
    */
   public abstract Attribute getValue(Identifier identifier);
+
+  /**
+   * Sets a new value for the given parameter name.
+   * 
+   * @param rawValue The new value of the parameter
+   * @param identifier Name of the parameter
+   * @return True if parameter is set, false otherwise.
+   */
+  public abstract Boolean setValue(Attribute rawValue, Identifier identifier);
+
 }


### PR DESCRIPTION
…on selected OBSW parameters

https://gitlab.com/esa/NMF/nmf-issues/-/issues/1192

Add onSetValue method in OBSWParameterManager and
OBSWParameterValuesProvider symmetrical to the onGetValue.
Update the DummyValuesProvider to accept setValue calls.
Add temporary map that stores parameters/values after
setValue calls.
Update the DummyValuesProvider to return the entries upon
calling getValue method.
Update MonitorAndControlNMFAdapter to always return false
for OBSW parameter isReadOnly() checks.
Refactor onSetValue in MonitorAndControlNMFAdapter.