### PR TITLE
Issue #1202 - Fix random null pointer exception in archive sync at startup

### DIFF
--- a/core/mo-services-impl/ccsds-com-impl/src/main/java/esa/mo/com/impl/provider/ArchiveSyncProviderServiceImpl.java
+++ b/core/mo-services-impl/ccsds-com-impl/src/main/java/esa/mo/com/impl/provider/ArchiveSyncProviderServiceImpl.java
@@ -114,6 +114,7 @@ public class ArchiveSyncProviderServiceImpl extends ArchiveSyncInheritanceSkelet
     public ArchiveSyncProviderServiceImpl(SingleConnectionDetails connectionToArchiveService, Blob authenticationId,
                                           String localNamePrefix)
     {
+        this.latestSync = new FineTime(0);
         try
         {
             this.archive =


### PR DESCRIPTION
This pull request contains changes preventing null pointer exception from being thrown during first synchronization.