### PR TITLE
Issue #1201 Backup provider command in COM Archive Tool

### DIFF
--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/ArchiveBrowserHelper.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/ArchiveBrowserHelper.java
@@ -154,6 +154,7 @@ public class ArchiveBrowserHelper {
    */
   public static LocalOrRemoteConsumer createConsumer(String providerURI, String databaseFile, String providerName) {
     // spawn our local provider on top of the given database file if needed
+    HelperMisc.loadPropertiesFile();
     ArchiveConsumerServiceImpl localConsumer = null;
     NMFConsumer remoteConsumer = null;
     if (providerURI == null) {
@@ -333,7 +334,7 @@ public class ArchiveBrowserHelper {
    * @return the ArchiveProviderServiceImpl
    */
   public static ArchiveProviderServiceImpl spawnLocalArchiveProvider(String databaseFile) {
-    HelperMisc.loadPropertiesFile();
+//    HelperMisc.loadPropertiesFile();
     System.setProperty(HelperMisc.PROP_MO_APP_NAME, COMArchiveTool.APP_NAME);
     System.setProperty("esa.nmf.archive.persistence.jdbc.url", "jdbc:sqlite:" + databaseFile);
 
@@ -343,7 +344,7 @@ public class ArchiveBrowserHelper {
       LOGGER.log(Level.INFO, String.format("ArchiveProvider initialized at %s with file %s",
           archiveProvider.getConnection().getConnectionDetails().getProviderURI(), databaseFile));
     } catch (MALException e) {
-      LOGGER.log(Level.SEVERE, "Error initializing archiveProdiver", e);
+      LOGGER.log(Level.SEVERE, "Error initializing archiveProvider", e);
     }
 
     // give it time to initialize

--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/COMArchiveTool.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/COMArchiveTool.java
@@ -37,6 +37,7 @@ import picocli.CommandLine.Option;
 @Command(name = "COMArchiveTool",
          subcommands = {LogsCommandsDefinitions.Logs.class,
                         ParametersCommandsDefinitions.Parameter.class,
+                        ArchiveCommandsDefinitions.BackupProvider.class,
                         ArchiveCommandsDefinitions.DumpRawArchive.class,
                         ArchiveCommandsDefinitions.DumpFormattedArchive.class,
                         ArchiveCommandsDefinitions.ListArchiveProviders.class},

--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/adapters/ArchiveToBackupAdapter.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/adapters/ArchiveToBackupAdapter.java
@@ -74,7 +74,7 @@ public class ArchiveToBackupAdapter extends ArchiveAdapter implements QueryStatu
         this.filename = filename + ".db";
       }
     } else {
-      DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd-MM-yyyy__HH-mm-ss");
+      DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd__HH-mm-ss");
       LocalDateTime now = LocalDateTime.now();
       this.filename = domain + "__" + dtf.format(now) + ".db";
     }

--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/adapters/ArchiveToBackupAdapter.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/adapters/ArchiveToBackupAdapter.java
@@ -1,0 +1,181 @@
+//------------------------------------------------------------------------------
+//
+// System : ccsds-common
+//
+// Sub-System : esa.mo.nmf.comarchivetool.adapters
+//
+// File Name : ArchiveToBackupAdapter.java
+//
+// Author : marcel.mikolajko
+//
+// Creation Date : 05.10.2022
+//
+//------------------------------------------------------------------------------
+package esa.mo.nmf.comarchivetool.adapters;
+
+import esa.mo.com.impl.provider.ArchiveProviderServiceImpl;
+import esa.mo.com.impl.util.ArchiveCOMObjectsOutput;
+import esa.mo.nmf.comarchivetool.ArchiveBrowserHelper;
+import org.ccsds.moims.mo.com.archive.consumer.ArchiveAdapter;
+import org.ccsds.moims.mo.com.archive.structures.ArchiveDetailsList;
+import org.ccsds.moims.mo.com.structures.ObjectType;
+import org.ccsds.moims.mo.mal.MALException;
+import org.ccsds.moims.mo.mal.MALInteractionException;
+import org.ccsds.moims.mo.mal.MALStandardError;
+import org.ccsds.moims.mo.mal.structures.ElementList;
+import org.ccsds.moims.mo.mal.structures.IdentifierList;
+import org.ccsds.moims.mo.mal.transport.MALMessageHeader;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author marcel.mikolajko
+ */
+public class ArchiveToBackupAdapter extends ArchiveAdapter implements QueryStatusProvider {
+
+  private static final Logger LOGGER = Logger.getLogger(ArchiveToJsonAdapter.class.getName());
+
+
+  /**
+   * Path to the destination database file
+   */
+  private final String filename;
+
+  /**
+   * List of objects to save
+   */
+  List<ArchiveCOMObjectsOutput> objectsToProcess = new ArrayList<>();
+
+  /**
+   * True if the query is over (response or any error received)
+   */
+  private boolean isQueryOver = false;
+
+  ArchiveProviderServiceImpl archive;
+
+  /**
+   * Creates a new instance of ToBackupArchiveAdapter.
+   *
+   * @param filename Path of destination database file
+   * */
+  public ArchiveToBackupAdapter(String filename, String domain) {
+    if (filename != null) {
+      if (filename.endsWith(".db")) {
+        this.filename= filename;
+      } else {
+        this.filename = filename + ".db";
+      }
+    } else {
+      DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd-MM-yyyy__HH-mm-ss");
+      LocalDateTime now = LocalDateTime.now();
+      this.filename = domain + "__" + dtf.format(now) + ".db";
+    }
+  }
+
+  public boolean saveDataToNewDatabase() {
+    File dbFile = new File(this.filename);
+    if (!dbFile.exists()) {
+        try {
+            dbFile.createNewFile();
+        } catch (IOException e) {
+          LOGGER.log(Level.SEVERE, "Failed to create new database file", e);
+          return false;
+        }
+    }
+    System.out.println("\nSaving data to " + this.filename + " started.\n");
+    this.archive = ArchiveBrowserHelper.spawnLocalArchiveProvider(this.filename);
+
+    boolean result = true;
+    for(ArchiveCOMObjectsOutput objects : objectsToProcess) {
+      try {
+        this.archive.store(false, objects.getObjectType(), objects.getDomain(), objects.getArchiveDetailsList(), objects.getObjectBodies(), null);
+      } catch (MALException | MALInteractionException e) {
+        LOGGER.log(Level.SEVERE, "Failed to store objects of type: " + objects.getObjectType(), e);
+        result = false;
+      }
+    }
+
+    System.out.println("\nSaving finished.\n");
+    return result;
+  }
+
+  public void closeArchiveProvider() {
+    this.archive.close();
+  }
+  /**
+   * Dumps an archive objects output received from an archive query answer (update or response).
+   *
+   * @param archiveObjectOutput the archive objects outputs
+   */
+  private synchronized void dumpArchiveObjectsOutput(ArchiveCOMObjectsOutput archiveObjectOutput) {
+    // empty comType means query returned nothing
+    ObjectType comType = archiveObjectOutput.getObjectType();
+    if (comType == null) {
+      return;
+    }
+    objectsToProcess.add(archiveObjectOutput);
+  }
+
+  @Override
+  public void queryResponseReceived(MALMessageHeader msgHeader, ObjectType objType,
+                                    IdentifierList domain, ArchiveDetailsList objDetails, ElementList objBodies,
+                                    Map qosProperties) {
+    dumpArchiveObjectsOutput(new ArchiveCOMObjectsOutput(domain, objType, objDetails, objBodies));
+    setIsQueryOver(true);
+  }
+
+  @Override
+  public void queryUpdateReceived(MALMessageHeader msgHeader, ObjectType objType,
+      IdentifierList domain, ArchiveDetailsList objDetails, ElementList objBodies,
+      Map qosProperties) {
+    dumpArchiveObjectsOutput(new ArchiveCOMObjectsOutput(domain, objType, objDetails, objBodies));
+  }
+
+  @Override
+  public void queryAckErrorReceived(MALMessageHeader msgHeader, MALStandardError error,
+      Map qosProperties) {
+    LOGGER.log(Level.SEVERE, "queryAckErrorReceived", error);
+    setIsQueryOver(true);
+  }
+
+  @Override
+  public void queryUpdateErrorReceived(MALMessageHeader msgHeader, MALStandardError error,
+      Map qosProperties) {
+    LOGGER.log(Level.SEVERE, "queryUpdateErrorReceived", error);
+    setIsQueryOver(true);
+  }
+
+  @Override
+  public void queryResponseErrorReceived(MALMessageHeader msgHeader, MALStandardError error,
+      Map qosProperties) {
+    LOGGER.log(Level.SEVERE, "queryResponseErrorReceived", error);
+    setIsQueryOver(true);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public synchronized boolean isQueryOver() {
+    return isQueryOver;
+  }
+
+  private synchronized void setIsQueryOver(boolean isQueryOver) {
+    if (isQueryOver) {
+      // once response or error is received, we dump current content to new database file
+//      saveDataToNewDatabase();
+    }
+    this.isQueryOver = isQueryOver;
+  }
+
+  public List<ArchiveCOMObjectsOutput> getObjectsToProcess() {
+    return objectsToProcess;
+  }
+}
+//------------------------------------------------------------------------------

--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/archive/ArchiveCommandsDefinitions.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/archive/ArchiveCommandsDefinitions.java
@@ -53,7 +53,7 @@ public class ArchiveCommandsDefinitions {
             ArchiveCommandsImplementations.dumpRawArchiveTables(databaseFile, jsonFile);
         }
     }
-    @Command(name = "backup_provider",
+    @Command(name = "backup_and_clean",
             description = "Backups the data for a specific provider")
     public static class BackupProvider implements Runnable {
         @Option(names = {"-h", "--help"}, usageHelp = true, description = "display a help message")

--- a/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/archive/ArchiveCommandsDefinitions.java
+++ b/sdk/tools/com-archive-tool/src/main/java/esa/mo/nmf/comarchivetool/commands/archive/ArchiveCommandsDefinitions.java
@@ -53,6 +53,32 @@ public class ArchiveCommandsDefinitions {
             ArchiveCommandsImplementations.dumpRawArchiveTables(databaseFile, jsonFile);
         }
     }
+    @Command(name = "backup_provider",
+            description = "Backups the data for a specific provider")
+    public static class BackupProvider implements Runnable {
+        @Option(names = {"-h", "--help"}, usageHelp = true, description = "display a help message")
+        boolean helpRequested;
+
+        @ArgGroup(multiplicity = "1")
+        ArchiveBrowserHelper.LocalOrRemote localOrRemote;
+
+        @Option(names = {"-o", "--output"}, paramLabel = "<filename>", description = "target file name")
+        String filename;
+
+        @Parameters(arity = "1", index = "0", paramLabel = "<domainId>",
+                description = "Restricts the dump to objects in a specific domain\n"
+                              + "  - format: key1.key2.[...].keyN.\n"
+                              + "  - example: esa.NMF_SDK.nanosat-mo-supervisor")
+        String domain;
+
+        @Option(names = {"-p", "--provider"}, paramLabel = "<appName>",
+                description = "Name of the NMF app we want to backup")
+        String appName;
+        @Override
+        public void run() {
+            ArchiveCommandsImplementations.backupProvider(localOrRemote.databaseFile, localOrRemote.providerURI, domain, appName, filename);
+        }
+    }
 
     @Command(name = "dump",
             description = "Dumps to a JSON file the formatted content of a local or remote COM archive")


### PR DESCRIPTION
This pull request adds a new command `backup_and_clean` to the COM Archive Tool allowing to backup and delete data from a provider.

Example usage:
`com-archive-tool backup_and_clean -r maltcp://127.0.0.1:61617/LWMCS_Core-Archive -p "App: LWMCS_Core" test.provider.domain`
This will save all the data from the test.provider.domain domain into the file `test.provider.domain__yyyy-MM-dd__HH-mm-ss.db` and delete the data from the provider archive if the save was succesfull.