### PR TITLE
Issue 1185 and 325

### DIFF
--- a/core/nmf-composites/generic-composite-model/src/main/java/esa/mo/nmf/MonitorAndControlNMFAdapter.java
+++ b/core/nmf-composites/generic-composite-model/src/main/java/esa/mo/nmf/MonitorAndControlNMFAdapter.java
@@ -91,8 +91,10 @@ public abstract class MonitorAndControlNMFAdapter implements ActionInvocationLis
         registration.setMode(MCRegistration.RegistrationMode.DONT_UPDATE_IF_EXISTS);
         registerParameters(registration);
         registerActions(registration);
-        archiveService = registration.comServices.getArchiveService();
-        parameterService = registration.parameterService;
+        if (registration.comServices != null) {
+            archiveService = registration.comServices.getArchiveService();
+            parameterService = registration.parameterService;
+        }
     }
 
     /**
@@ -258,7 +260,7 @@ public abstract class MonitorAndControlNMFAdapter implements ActionInvocationLis
     }
 
     public void setParameterValuesFromArchive() {
-        if (archiveService != null) {
+        if (archiveService != null && parameterService != null) {
             for (Map.Entry<Long, Field> entry : parameterMapping.entrySet()) {
                 Field field = entry.getValue();
                 String parameterName = null;

--- a/core/nmf-composites/generic-composite-model/src/main/java/esa/mo/nmf/MonitorAndControlNMFAdapter.java
+++ b/core/nmf-composites/generic-composite-model/src/main/java/esa/mo/nmf/MonitorAndControlNMFAdapter.java
@@ -84,7 +84,7 @@ public abstract class MonitorAndControlNMFAdapter implements ActionInvocationLis
     private final HashMap<String, Long> actionNameMapping = new HashMap<>();
 
     private ArchiveProviderServiceImpl archiveService;
-    private ParameterProviderServiceImpl parameterService;
+    protected ParameterProviderServiceImpl parameterService;
 
     public void initialRegistrations(MCRegistration registration) {
         // Prevent definition updates on consecutive application runs

--- a/core/nmf-composites/generic-composite-model/src/main/java/esa/mo/nmf/annotations/Parameter.java
+++ b/core/nmf-composites/generic-composite-model/src/main/java/esa/mo/nmf/annotations/Parameter.java
@@ -127,6 +127,13 @@ public @interface Parameter {
     boolean readOnly() default false;
 
     /**
+     * If this parameter should have its value restored from archive on startup.
+     *
+     * default: true
+     */
+    boolean restored() default true;
+
+    /**
      * The name of the function that will be called, every time the Parameter is get (before its value
      * is read).
      *

--- a/core/nmf-composites/nanosat-mo-connector/src/main/java/esa/mo/nmf/nanosatmoconnector/NanoSatMOConnectorImpl.java
+++ b/core/nmf-composites/nanosat-mo-connector/src/main/java/esa/mo/nmf/nanosatmoconnector/NanoSatMOConnectorImpl.java
@@ -279,7 +279,7 @@ public class NanoSatMOConnectorImpl extends NMFProvider {
             MCRegistration registration = new MCRegistration(comServices, mcServices.getParameterService(), mcServices
                 .getAggregationService(), mcServices.getAlertService(), mcServices.getActionService());
             mcAdapter.initialRegistrations(registration);
-            mcAdapter.setParameterValuesFromArchive();
+            mcAdapter.restoreParameterValuesFromArchive();
         }
 
         LOGGER.log(Level.INFO, "NanoSat MO Connector initialized in " + (((float) (System.currentTimeMillis() -
@@ -552,7 +552,7 @@ public class NanoSatMOConnectorImpl extends NMFProvider {
             MCRegistration registration = new MCRegistration(comServices, mcServices.getParameterService(), mcServices
                 .getAggregationService(), mcServices.getAlertService(), mcServices.getActionService());
             mcAdapter.initialRegistrations(registration);
-            mcAdapter.setParameterValuesFromArchive();
+            mcAdapter.restoreParameterValuesFromArchive();
         }
 
         if (mpAdapter != null) {

--- a/core/nmf-composites/nanosat-mo-connector/src/main/java/esa/mo/nmf/nanosatmoconnector/NanoSatMOConnectorImpl.java
+++ b/core/nmf-composites/nanosat-mo-connector/src/main/java/esa/mo/nmf/nanosatmoconnector/NanoSatMOConnectorImpl.java
@@ -279,6 +279,7 @@ public class NanoSatMOConnectorImpl extends NMFProvider {
             MCRegistration registration = new MCRegistration(comServices, mcServices.getParameterService(), mcServices
                 .getAggregationService(), mcServices.getAlertService(), mcServices.getActionService());
             mcAdapter.initialRegistrations(registration);
+            mcAdapter.setParameterValuesFromArchive();
         }
 
         LOGGER.log(Level.INFO, "NanoSat MO Connector initialized in " + (((float) (System.currentTimeMillis() -
@@ -551,6 +552,7 @@ public class NanoSatMOConnectorImpl extends NMFProvider {
             MCRegistration registration = new MCRegistration(comServices, mcServices.getParameterService(), mcServices
                 .getAggregationService(), mcServices.getAlertService(), mcServices.getActionService());
             mcAdapter.initialRegistrations(registration);
+            mcAdapter.setParameterValuesFromArchive();
         }
 
         if (mpAdapter != null) {

--- a/docs/source/cli-tool.rst
+++ b/docs/source/cli-tool.rst
@@ -1,0 +1,373 @@
+CLI Tool
+================================================
+
+.. contents:: Table of contents
+    :local:
+
+Archive Commands
+-----------------
+* dump_raw::
+
+    Usage: esa.mo.nmf.clitool.CLITool archive dump_raw [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>] <jsonFile>
+    Dumps to a JSON file the raw tables content of a local COM archive
+          <jsonFile>                  target JSON file
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+* dump::
+
+    Usage: esa.mo.nmf.clitool.CLITool archive dump [-h] [-d=<domainId>] [-e=<endTime>] [-l=<databaseFile>] [-p=<providerName>]
+                                                   [-r=<providerURI>] [-s=<startTime>] [-t=<comType>] <jsonFile>
+    Dumps to a JSON file the formatted content of a local or remote COM archive
+          <jsonFile>                  target JSON file
+      -d, --domain=<domainId>         Restricts the dump to objects in a specific domain
+                                        - format: key1.key2.[...].keyN.
+                                        - example: esa.NMF_SDK.nanosat-mo-supervisor
+      -e, --end=<endTime>             Restricts the dump to objects created before the given time. If this option is provided without the
+                                        -s option, returns the single object that has the closest timestamp to, but not greater than
+                                        <endTime>
+                                        - format: "yyyy-MM-dd HH:mm:ss.SSS"
+                                        - example: "2021-03-05 12:05:45.271"
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+      -s, --start=<startTime>         Restricts the dump to objects created after the given time
+                                        - format: "yyyy-MM-dd HH:mm:ss.SSS"
+                                        - example: "2021-03-04 08:37:58.482"
+      -t, --type=<comType>            Restricts the dump to objects that are instances of <comType>
+                                        - format: areaNumber.serviceNumber.areaVersion.objectNumber.
+                                        - examples (0=wildcard): 4.2.1.1, 4.2.1.0
+
+* list::
+
+    Usage: esa.mo.nmf.clitool.CLITool archive list [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>] <centralDirectoryURI>
+    Lists the COM archive providers URIs found in a central directory
+          <centralDirectoryURI>       URI of the central directory to use
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+* backup_and_clean::
+
+    Usage: esa.mo.nmf.clitool.CLITool archive backup_and_clean [-h] [-l=<databaseFile>] [-o=<filename>] [-p=<providerName>]
+                                                               [-r=<providerURI>] <domainId>
+    Backups the data for a specific provider
+          <domainId>                  Restricts the dump to objects in a specific domain
+                                        - format: key1.key2.[...].keyN.
+                                        - example: esa.NMF_SDK.nanosat-mo-supervisor
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -o, --output=<filename>         target file name
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+Logs Commands
+-------------
+* list::
+
+    Usage: esa.mo.nmf.clitool.CLITool log list [-h] [-d=<domainId>] [-e=<endTime>] [-l=<databaseFile>] [-p=<providerName>]
+                                               [-r=<providerURI>] [-s=<startTime>]
+    Lists NMF apps having logs in the content of a local or remote COM archive.
+      -d, --domain=<domainId>         Restricts the list to NMF apps in a specific domain
+                                        - default: search for app in all domains
+                                        - format: key1.key2.[...].keyN.
+                                        - example: esa.NMF_SDK.nanosat-mo-supervisor
+      -e, --end=<endTime>             Restricts the list to NMF apps having logs logged before the given time. If this option is provided
+                                        without the -s option, returns the single object that has the closest timestamp to, but not greater
+                                        than <endTime>
+                                        - format: "yyyy-MM-dd HH:mm:ss.SSS"
+                                        - example: "2021-03-05 12:05:45.271"
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+      -s, --start=<startTime>         Restricts the list to NMF apps having logs logged after the given time
+                                        - format: "yyyy-MM-dd HH:mm:ss.SSS"
+                                        - example: "2021-03-04 08:37:58.482"
+
+* get::
+
+    Usage: esa.mo.nmf.clitool.CLITool log get [-ht] [-d=<domainId>] [-e=<endTime>] [-l=<databaseFile>] [-p=<providerName>]
+                                              [-r=<providerURI>] [-s=<startTime>] <appName> <logFile>
+    Dumps to a LOG file an NMF app logs using the content of a local or remote COM archive.
+          <appName>                   Name of the NMF app we want the logs for
+          <logFile>                   target LOG file
+      -d, --domain=<domainId>         Domain of the NMF app we want the logs for
+                                        - default: search for app in all domains
+                                        - format: key1.key2.[...].keyN.
+                                        - example: esa.NMF_SDK.nanosat-mo-supervisor
+      -e, --end=<endTime>             Restricts the dump to logs logged before the given time. If this option is provided without the -s
+                                        option, returns the single object that has the closest timestamp to, but not greater than <endTime>
+                                        - format: "yyyy-MM-dd HH:mm:ss.SSS"
+                                        - example: "2021-03-05 12:05:45.271"
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+      -s, --start=<startTime>         Restricts the dump to logs logged after the given time
+                                        - format: "yyyy-MM-dd HH:mm:ss.SSS"
+                                        - example: "2021-03-04 08:37:58.482"
+      -t, --timestamped               If specified additional timestamp will be added to each line
+
+MC Commands
+-----------
+
+Parameters
+^^^^^^^^^^
+* subscribe::
+
+    Usage: esa.mo.nmf.clitool.CLITool parameter subscribe [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>]
+                                                          [<parameterNames>...]
+    Subscribes to specified parameters
+          [<parameterNames>...]       Names of the parameters to subscribe to. If non are specified subscribe to all.
+                                       - examples: param1 or param1 param2
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+* enable::
+
+    Usage: esa.mo.nmf.clitool.CLITool parameter enable [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>] [<parameterNames>...]
+    Enables generation of specified parameters
+          [<parameterNames>...]       Names of the parameters to enable. If non are specified enable all
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+* disable::
+
+    Usage: esa.mo.nmf.clitool.CLITool parameter disable [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>]
+                                                        [<parameterNames>...]
+    Disables generation of specified parameters
+          [<parameterNames>...]       Names of the parameters to disable. If non are specified disable all
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+* get::
+
+    Usage: esa.mo.nmf.clitool.CLITool parameter get [-hj] [-d=<domainId>] [-e=<endTime>] [-l=<databaseFile>] [-p=<providerName>]
+                                                    [-r=<providerURI>] [-s=<startTime>] <filename> [<parameterNames>...]
+    Dumps to a file MO parameters samples from COM archive.
+          <filename>                  Target file for the parameters samples
+          [<parameterNames>...]       Names of the parameters to retrieve
+                                       - examples: param1 or param1 param2
+      -d, --domain=<domainId>         Restricts the dump to parameters in a specific domain
+                                        - format: key1.key2.[...].keyN.
+                                        - example: esa.NMF_SDK.nanosat-mo-supervisor
+      -e, --end=<endTime>             Restricts the dump to parameters generated before the given time. If this option is provided without
+                                        the -s option, returns the single object that has the closest timestamp to, but not greater than
+                                        <endTime>
+                                        - format: "yyyy-MM-dd HH:mm:ss.SSS"
+                                        - example: "2021-03-05 12:05:45.271"
+      -h, --help                      display a help message
+      -j, --json                      If specified output will be in JSON format
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+      -s, --start=<startTime>         Restricts the dump to parameters generated after the given time
+                                        - format: "yyyy-MM-dd HH:mm:ss.SSS"
+                                        - example: "2021-03-04 08:37:58.482"
+
+* list::
+
+    Usage: esa.mo.nmf.clitool.CLITool parameter list [-h] [-d=<domainId>] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>]
+    Lists available parameters in a COM archive.
+      -d, --domain=<domainId>         Restricts the dump to objects in a specific domain
+                                        - format: key1.key2.[...].keyN.
+                                        - example: esa.NMF_SDK.nanosat-mo-supervisor
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+Aggregations
+^^^^^^^^^^^^
+* subscribe::
+
+    Usage: esa.mo.nmf.clitool.CLITool aggregation subscribe [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>]
+                                                            [<parameterNames>...]
+    Subscribes to specified aggregations
+          [<parameterNames>...]       Names of the aggregations to subscribe to. If non are specified subscribe to all.
+                                       - examples: aggregation1 or aggregation1 aggregation2
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+* enable::
+
+    Usage: esa.mo.nmf.clitool.CLITool aggregation enable [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>]
+                                                         [<aggregationNames>...]
+    Enables generation of specified aggregations
+          [<aggregationNames>...]     Names of the aggregations to enable. If non are specified enable all
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+* disable::
+
+    Usage: esa.mo.nmf.clitool.CLITool aggregation disable [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>]
+                                                          [<aggregationNames>...]
+    Disables generation of specified aggregations
+          [<aggregationNames>...]     Names of the aggregations to disable. If non are specified disable all
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+
+Platform Commands
+-----------------
+
+GPS
+^^^
+* get-nmea-sentence::
+
+    Usage: esa.mo.nmf.clitool.CLITool gps get-nmea-sentence [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>]
+                                                            <sentenceIdentifier>
+    Gets the NMEA sentence
+          <sentenceIdentifier>        Identifier of the sentence
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+ADCS
+^^^^
+* get-status::
+
+    Usage: esa.mo.nmf.clitool.CLITool adcs get-status [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>]
+    Gets the provider status
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+Camera
+^^^^^^
+* take-picture::
+
+    Usage: esa.mo.nmf.clitool.CLITool camera take-picture [-h] [-exp=<exposureTime>] [-fmt=<format>] [-gb=<gainBlue>] [-gg=<gainGreen>]
+                                                          [-gr=<gainRed>] [-l=<databaseFile>] [-o=<outputFile>] [-p=<providerName>]
+                                                          [-r=<providerURI>] -res=<resolution>
+    Take a picture from the camera
+      -exp, --exposure=<exposureTime> Exposure time of the picture
+      -fmt, --format=<format>         Format of the image
+      -gb,  --gain-blue=<gainBlue>    Gain of the blue channel
+      -gg,  --gain-green=<gainGreen>  Gain of the green channel
+      -gr,  --gain-red=<gainRed>      Gain of the red channel
+      -h,   --help                    display a help message
+      -l,   --local=<databaseFile>    Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -o,   --output=<outputFile>     Name of the output file without the extension.
+      -p,   --provider=<providerName> Name of the provider we want to connect to
+      -r,   --remote=<providerURI>    Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+      -res, --resolution=<resolution> Resolution of the image in format widthxheigh. For example 1920x1080
+
+Software Management Commands
+----------------------------
+Apps Launcher
+^^^^^^^^^^^^^
+* subscribe::
+
+    Usage: esa.mo.nmf.clitool.CLITool apps-launcher subscribe [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>]
+                                                              [<appNames>...]
+    Subscribes to app's stdout
+          [<appNames>...]             Names of the apps to subscribe to. If non are specified subscribe to all.
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+* run::
+
+    Usage: esa.mo.nmf.clitool.CLITool apps-launcher run [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>] <appName>
+    Runs the specified provider app
+          <appName>                   Name of the app to run.
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+* stop::
+
+    Usage: esa.mo.nmf.clitool.CLITool apps-launcher stop [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>] <appName>
+    Stops the specified provider app
+          <appName>                   Name of the app to stop.
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+* kill::
+
+    Usage: esa.mo.nmf.clitool.CLITool apps-launcher kill [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>] <appName>
+    Kills the specified provider app
+          <appName>                   Name of the app to kill.
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory
+
+Heartbeat
+^^^^^^^^^
+* subscribe::
+
+    Usage: esa.mo.nmf.clitool.CLITool heartbeat subscribe [-h] [-l=<databaseFile>] [-p=<providerName>] [-r=<providerURI>]
+    Subscribes to provider's heartbeat
+      -h, --help                      display a help message
+      -l, --local=<databaseFile>      Local SQLite database file
+                                        - example: ../nanosat-mo-supervisor-sim/comArchive.db
+      -p, --provider=<providerName>   Name of the provider we want to connect to
+      -r, --remote=<providerURI>      Provider URI
+                                        - example: maltcp://10.0.2.15:1024/nanosat-mo-supervisor-Directory

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,6 +26,7 @@ You can also just click through the different pages to see what we can offer.
    opssat/opssat
    javadoc/packages
    mpservices/mp
+   cli-tool
 
 Indices and tables
 ==================

--- a/sdk/examples/space/payloads-test/src/main/java/esa/mo/nmf/apps/PayloadsTestApp.java
+++ b/sdk/examples/space/payloads-test/src/main/java/esa/mo/nmf/apps/PayloadsTestApp.java
@@ -41,6 +41,8 @@ public class PayloadsTestApp {
         ConnectionConsumer connectionConsumer = new ConnectionConsumer();
         connectionConsumer.loadURIs();
         adapter.setSimpleCommandingInterface(new CommonMOAdapterImpl(connectionConsumer));
+
+        adapter.subscribeToSupervisorParameters(connector.readCentralDirectoryServiceURI());
     }
 
 }

--- a/sdk/examples/space/payloads-test/src/main/java/esa/mo/nmf/apps/PayloadsTestMCAdapter.java
+++ b/sdk/examples/space/payloads-test/src/main/java/esa/mo/nmf/apps/PayloadsTestMCAdapter.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -56,6 +57,7 @@ import org.ccsds.moims.mo.common.directory.structures.ProviderSummaryList;
 import org.ccsds.moims.mo.common.directory.structures.ServiceFilter;
 import org.ccsds.moims.mo.common.structures.ServiceKey;
 import org.ccsds.moims.mo.mal.MALException;
+import org.ccsds.moims.mo.mal.MALHelper;
 import org.ccsds.moims.mo.mal.MALInteractionException;
 import org.ccsds.moims.mo.mal.provider.MALInteraction;
 import org.ccsds.moims.mo.mal.structures.*;
@@ -91,6 +93,8 @@ import org.ccsds.moims.mo.platform.structures.VectorF3D;
 @Aggregation(id = PayloadsTestMCAdapter.AGGREGATION_IADCS_TELEMETRY, description = "iADCS telemetry data",
              reportInterval = 5, sendUnchanged = true, sampleInterval = 3, generationEnabled = true)
 public class PayloadsTestMCAdapter extends MonitorAndControlNMFAdapter {
+    // comma separated list of supervisor parameters to proxy
+    public static final String SUPERVISOR_PARAMETER_PROXY_PROP = "esa.mo.nanosatmoframework.proxy.supervisor.parameters";
     public static final String AGGREGATION_MAG = "Magnetometer_Aggregation";
     public static final String AGGREGATION_GPS = "GPS_Aggregation";
     public static final String AGGREGATION_ECLIPSED = "Eclipsed_Aggregation";
@@ -189,31 +193,31 @@ public class PayloadsTestMCAdapter extends MonitorAndControlNMFAdapter {
     Float MagneticField_Z = 0.0f;
 
     //-------------------------------------- Supervisor Parameters ----------------------------------
-    @Parameter(name = "CADC0884", description = "I_PD1_THETA", generationEnabled = false, readOnly = true,
-               reportIntervalSeconds = 10, aggregations = {AGGREGATION_ECLIPSED})
+    @Parameter(name = "CADC0884", description = "I_PD1_THETA", generationEnabled = false, reportIntervalSeconds = 5,
+               aggregations = {AGGREGATION_ECLIPSED})
     Float IPD1Theta = 0.0f;
 
-    @Parameter(name = "CADC0886", description = "I_PD2_THETA", generationEnabled = false, readOnly = true,
-               reportIntervalSeconds = 10, aggregations = {AGGREGATION_ECLIPSED})
+    @Parameter(name = "CADC0886", description = "I_PD2_THETA", generationEnabled = false, reportIntervalSeconds = 5,
+               aggregations = {AGGREGATION_ECLIPSED})
     Float IPD2Theta = 0.0f;
 
-    @Parameter(name = "CADC0888", description = "I_PD3_THETA", generationEnabled = false, readOnly = true,
-               reportIntervalSeconds = 10, aggregations = {AGGREGATION_ECLIPSED})
+    @Parameter(name = "CADC0888", description = "I_PD3_THETA", generationEnabled = false, reportIntervalSeconds = 5,
+               aggregations = {AGGREGATION_ECLIPSED})
     Float IPD3Theta = 0.0f;
 
-    @Parameter(name = "CADC0890", description = "I_PD4_THETA", generationEnabled = false, readOnly = true,
-               reportIntervalSeconds = 10, aggregations = {AGGREGATION_ECLIPSED})
+    @Parameter(name = "CADC0890", description = "I_PD4_THETA", generationEnabled = false, reportIntervalSeconds = 5,
+               aggregations = {AGGREGATION_ECLIPSED})
     Float IPD4Theta = 0.0f;
 
-    @Parameter(name = "CADC0892", description = "I_PD5_THETA", generationEnabled = false, readOnly = true,
-               reportIntervalSeconds = 10, aggregations = {AGGREGATION_ECLIPSED})
+    @Parameter(name = "CADC0892", description = "I_PD5_THETA", generationEnabled = false, reportIntervalSeconds = 5,
+               aggregations = {AGGREGATION_ECLIPSED})
     Float IPD5Theta = 0.0f;
 
-    @Parameter(name = "CADC0894", description = "I_PD6_THETA", generationEnabled = false, readOnly = true,
-               reportIntervalSeconds = 10, aggregations = {AGGREGATION_ECLIPSED})
+    @Parameter(name = "CADC0894", description = "I_PD6_THETA", generationEnabled = false, reportIntervalSeconds = 5,
+               aggregations = {AGGREGATION_ECLIPSED})
     Float IPD6Theta = 0.0f;
 
-    @Parameter(generationEnabled = false, readOnly = true, reportIntervalSeconds = 1, onGetFunction = "onGetEclipsed")
+    @Parameter(generationEnabled = false, readOnly = true, reportIntervalSeconds = 5, onGetFunction = "onGetEclipsed")
     Boolean eclipsed = false;
     final static Float ECLIPSED_EPSILON = 0.001f;
 
@@ -444,25 +448,51 @@ public class PayloadsTestMCAdapter extends MonitorAndControlNMFAdapter {
                             .getObjIdentityInstanceId());
                     }
 
+                    String parametersProp = System.getProperty(SUPERVISOR_PARAMETER_PROXY_PROP, null);
+
                     IdentifierList supervisorParameters = new IdentifierList();
-                    supervisorParameters.add(new Identifier("SBD6682p"));
-                    supervisorParameters.add(new Identifier("SBD6692p"));
-                    supervisorParameters.add(new Identifier("SBD6702p"));
-                    supervisorParameters.add(new Identifier("SBD6712p"));
-                    supervisorParameters.add(new Identifier("SBD6722p"));
-                    supervisorParameters.add(new Identifier("SBD6732p"));
-                    supervisorParameters.add(new Identifier("SBD6742p"));
-                    supervisorParameters.add(new Identifier("SBD6752p"));
-                    supervisorParameters.add(new Identifier("SBD6762p"));
-                    supervisorParameters.add(new Identifier("SBD6772p"));
-                    supervisorParameters.add(new Identifier("SBD6862p"));
-                    supervisorParameters.add(new Identifier("SBD6872p"));
+                    if (parametersProp == null) {
+                        supervisorParameters.add(new Identifier("SBD6682p"));
+                        supervisorParameters.add(new Identifier("SBD6692p"));
+                        supervisorParameters.add(new Identifier("SBD6702p"));
+                        supervisorParameters.add(new Identifier("SBD6712p"));
+                        supervisorParameters.add(new Identifier("SBD6722p"));
+                        supervisorParameters.add(new Identifier("SBD6732p"));
+                        supervisorParameters.add(new Identifier("SBD6742p"));
+                        supervisorParameters.add(new Identifier("SBD6752p"));
+                        supervisorParameters.add(new Identifier("SBD6762p"));
+                        supervisorParameters.add(new Identifier("SBD6772p"));
+                        supervisorParameters.add(new Identifier("SBD6862p"));
+                        supervisorParameters.add(new Identifier("SBD6872p"));
+                    } else {
+                        parametersProp = parametersProp.replace("\"", "");
+                        String[] parameters = parametersProp.split(",");
+                        for (String parameter : parameters) {
+                            supervisorParameters.add(new Identifier(parameter.trim()));
+                        }
+                    }
 
                     IdentifierList parameterNames = new IdentifierList();
                     parameterNames.addAll(supervisorParameters);
                     parameterNames.addAll(eclipsedParameters);
-                    ObjectInstancePairList supervisorIds = supervisorParameterService.getParameterStub().listDefinition(
-                        parameterNames);
+                    ObjectInstancePairList supervisorIds = new ObjectInstancePairList();
+                    try {
+                        supervisorIds = supervisorParameterService.getParameterStub().listDefinition(parameterNames);
+                    } catch (MALInteractionException e) {
+                        if (e.getStandardError().getErrorNumber().equals(MALHelper.UNKNOWN_ERROR_NUMBER)) {
+                            UIntegerList unknownParams = (UIntegerList) e.getStandardError().getExtraInformation();
+                            for (UInteger index : unknownParams) {
+                                parameterNames.set((int) index.getValue(), null);
+                            }
+                            parameterNames.removeIf(Objects::isNull);
+
+                            if (!parameterNames.isEmpty()) {
+                                supervisorIds = supervisorParameterService.getParameterStub().listDefinition(
+                                    parameterNames);
+                            }
+                        }
+                    }
+
                     InstanceBooleanPairList enable = new InstanceBooleanPairList();
                     for (ObjectInstancePair id : supervisorIds) {
                         enable.add(new InstanceBooleanPair(id.getObjIdentityInstanceId(), true));

--- a/sdk/tools/cli-tool/pom.xml
+++ b/sdk/tools/cli-tool/pom.xml
@@ -8,7 +8,7 @@
         <groupId>int.esa.nmf</groupId>
         <artifactId>parent</artifactId>
         <version>2.1.0-SNAPSHOT</version>
-        <relativePath>../../../pom.xml</relativePath>
+        <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>int.esa.nmf.sdk</groupId>

--- a/sdk/tools/cli-tool/src/main/java/esa/mo/nmf/clitool/BaseCommand.java
+++ b/sdk/tools/cli-tool/src/main/java/esa/mo/nmf/clitool/BaseCommand.java
@@ -108,6 +108,7 @@ public abstract class BaseCommand {
         if (!initLocalArchiveProvider(databaseFile)) {
             return false;
         }
+        NMFConsumer.initHelpers();
         String providerURI = localArchiveProvider.getConnection().getConnectionDetails().getProviderURI().getValue();
         SingleConnectionDetails connectionDetails = new SingleConnectionDetails();
         connectionDetails.setProviderURI(providerURI);


### PR DESCRIPTION
This pull request contains changes for issues 1185, 325 and fixes/improvements that were discussed during LWMCS/NMF CCN2 final presentation.
Changes in this pull request:
Issue 1185:
- new parameter `eclipsed` derived from supervisor parameters
- new aggregation with CADC0884, CADC0886, CADC0888, CADC0890, CADC0892, CADC0894
- more iADCS parameters exposed: 
  - attitude quaternion
  - angular velocity
  - sun vector
  - state target
  - magnetorquers dipole moment
  - magnetorquers state
- new aggregation with all iADCS parameters
- new parameter `supervisorTMPollingEnabled`  - when true specified parameters will be polled from the supervisor and their values will be printed to stdout. The parameters are loaded from the `esa.mo.nanosatmoframework.proxy.supervisor.parameters` property.
- 3 new actions allowing to set the following attitude modes: B-dot, target, tracking, single spinning
- decreased verbosity of the gps error - only the exception message will be printed instead of the whole stack

Issue 325:
- provider parameter values are now restored from the archive during app's startup

Other changes:
- fixed CLI Tool parent in pom.xml
- added a CLI Tool section to the documentation
- fixed a null pointer exception in `parameter get` command in CLI Tool
- new `restored` flag in `@Parameter` annotation that allows to exclude parameters from being restored