### PR TITLE
phi-sat-2: add default value to hasFixedResolutions() for backwards compatibility

### DIFF
--- a/core/mo-services-impl/nmf-platform-generic-impl/src/main/java/esa/mo/platform/impl/provider/gen/CameraAdapterInterface.java
+++ b/core/mo-services-impl/nmf-platform-generic-impl/src/main/java/esa/mo/platform/impl/provider/gen/CameraAdapterInterface.java
@@ -44,8 +44,11 @@ public interface CameraAdapterInterface {
     /**
      * @return true if the camera has only a fixed set of resolutions. They can
      * then be retrieved with the getAvailableResolutions() method.
+     * The default is true to be backwards compatible with earlier impementations.
      */
-    boolean hasFixedResolutions();
+    default boolean hasFixedResolutions() {
+        return true; 
+    };
 
     /**
      * @return The resolutions supported by the Camera Adapter


### PR DESCRIPTION
In the phi-sat-2 branch, the `boolean hasFixedResolutions()` has been added to better support new hardware, when trying to setup the https://github.com/NanoSat-MO-Framework/nmf-mission-raspberry-pi this produced a compile error. 

To be backwards compatible with other implementations (including OPS-SAT) a small fix is suggested that introduces default behaviour if `hasFixedResolutions()` is not implemented.